### PR TITLE
Fix asset lookup of HOME directory

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -114,7 +114,7 @@ func extract(dataDir string) (string, error) {
 	asset, dir = getAssetAndDir(dataDir)
 	if _, err := os.Stat(dir); err == nil {
 		logrus.Debugf("Asset dir %s", dir)
-		return "", nil
+		return dir, nil
 	}
 
 	logrus.Infof("Preparing data dir %s", dir)


### PR DESCRIPTION
Return the directory name if assets are located in HOME, so we can
properly set the PATH for binary lookup.

For rancher/k3s/issues/38 and rancher/k3s/issues/21