### PR TITLE
Chmod /tmp to 1777 for e2e tests

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -9,6 +9,7 @@ RUN cd image/bin && \
 
 FROM scratch
 COPY --from=base /image /
+RUN chmod 1777 /tmp
 VOLUME /var/lib/rancher/k3s 
 VOLUME /var/lib/cni
 VOLUME /var/log


### PR DESCRIPTION
The kubernetes e2e tests will mount /tmp and verify permissions, fix
to match the expectations of the test for our image.

For rancher/k3s/issues/45