### PR TITLE
Make systemd notify optional in generic api server

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -44,6 +44,10 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
+var (
+	NotifySystemD = true
+)
+
 // Info about an API group.
 type APIGroupInfo struct {
 	PrioritizedVersions []schema.GroupVersion
@@ -292,8 +296,10 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 
 	s.RunPostStartHooks(stopCh)
 
-	if _, err := systemd.SdNotify(true, "READY=1\n"); err != nil {
-		klog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
+	if NotifySystemD {
+		if _, err := systemd.SdNotify(true, "READY=1\n"); err != nil {
+			klog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
+		}
 	}
 
 	return nil
@@ -405,9 +411,9 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Typer:           apiGroupInfo.Scheme,
 		Linker:          runtime.SelfLinker(meta.NewAccessor()),
 
-		Admit:                        s.admissionControl,
-		MinRequestTimeout:            s.minRequestTimeout,
-		Authorizer:                   s.Authorizer,
+		Admit:             s.admissionControl,
+		MinRequestTimeout: s.minRequestTimeout,
+		Authorizer:        s.Authorizer,
 	}
 }
 


### PR DESCRIPTION
To properly notify systemd that the k3s server is ready we need to
prevent the current k8s notification and add one to the k3s cli.

For rancher/k3s/issues/57