### PR TITLE
fix 'fannel' typo.

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, config *config.Node) error {
 
 	go func() {
 		err := flannel(ctx, config.FlannelConf, config.AgentConfig.KubeConfig)
-		logrus.Fatalf("fannel exited: %v", err)
+		logrus.Fatalf("flannel exited: %v", err)
 	}()
 
 	return err


### PR DESCRIPTION
It seems like a lot of users are getting issues with flannel initially. This will help them get the 'right' error message 👍 