### PR TITLE
Update README.md: you have a great install script, don't hide it

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ k3s is intended to be a fully compliant Kubernetes distribution with the followi
     
 Quick Start
 -----------
-1. Download `k3s` from latest [release](https://github.com/rancher/k3s/releases/latest), x86_64, armhf, and arm64 are
-   supported
+1. Download `k3s` from [latest](https://github.com/rancher/k3s/releases/latest) (x86_64, armhf, arm64) or run the install script via `curl -L https://get.k3s.io | sh -`
 2. Run server 
 
 ```bash


### PR DESCRIPTION
k3s has such a great install script with an even better URL (https://get.k3s.io), don't hide it, let's put it in the README.md above the fold. The script is much easier than downloading and fiddling around with the release. I also shortened the text in 1 a bit to fit it on one line when rendered.