### PR TITLE
preload a docker image on the k3s node agents

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -161,6 +161,7 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 	}
 	nodeConfig.LocalAddress = localAddress(controlConfig)
+	nodeConfig.Images = "/var/lib/rancher/k3s/agent/images"
 	nodeConfig.AgentConfig.NodeIP = nodeIP
 	nodeConfig.AgentConfig.NodeName = nodeName
 	nodeConfig.AgentConfig.ClusterDNS = controlConfig.ClusterDNS

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -161,7 +161,7 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 	}
 	nodeConfig.LocalAddress = localAddress(controlConfig)
-	nodeConfig.Images = "/var/lib/rancher/k3s/agent/images"
+	nodeConfig.Images = filepath.Join(envInfo.DataDir, "images")
 	nodeConfig.AgentConfig.NodeIP = nodeIP
 	nodeConfig.AgentConfig.NodeName = nodeName
 	nodeConfig.AgentConfig.ClusterDNS = controlConfig.ClusterDNS

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -16,6 +16,7 @@ type Node struct {
 	FlannelConf              string
 	LocalAddress             string
 	Containerd               Containerd
+	Images                   string
 	AgentConfig              Agent
 	CACerts                  []byte
 	ServerAddress            string


### PR DESCRIPTION
This PR adds preloading existing container images ( `docker save` format ) from `/var/lib/rancher/k3s/agent/images`

Fixes #92 