### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ helper scripts
 ./scripts/dev-agent.sh
 ```
 
-To build the full release binary run `make` and that will create `./dist/k3s`
+To build the full release binary run `make` and that will create `./dist/artifacts/k3s`
 
 Kubernetes Source
 -----------------


### PR DESCRIPTION
Hello.
See diffs. It should be `./dist/artifacts/k3s`