### PR TITLE
Fix node token path

### DIFF
--- a/scripts/dev-agent.sh
+++ b/scripts/dev-agent.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+. setup-rancher-path.sh
+
 cd $(dirname $0)/..
 
 # Prime sudo
@@ -15,4 +17,4 @@ else
 fi
 
 echo Starting agent
-sudo env "PATH=$(pwd)/bin:$PATH" ./bin/k3s-agent --debug agent -s https://localhost:6443 -t $(<${HOME}/.rancher/k3s/server/node-token) "$@"
+sudo env "PATH=$(pwd)/bin:$PATH" ./bin/k3s-agent --debug agent -s https://localhost:6443 -t $(<${RANCHER_PATH}/k3s/server/node-token) "$@"

--- a/scripts/dev-docker-agent.sh
+++ b/scripts/dev-docker-agent.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. setup-rancher-path.sh
+
 cd $(dirname $0)/..
 IP=$(ip addr show dev docker0 | grep -w inet | awk '{print $2}' | cut -f1 -d/)
 docker run \
@@ -16,4 +18,4 @@ docker run \
     -v /var/lib/cni \
     -v /usr/lib/x86_64-linux-gnu/libsqlite3.so.0:/usr/lib/x86_64-linux-gnu/libsqlite3.so.0:ro \
     --privileged \
-    ubuntu:18.04 /usr/bin/k3s-agent agent -t $(<~/.rancher/k3s/server/node-token) -s https://${IP}:6443
+    ubuntu:18.04 /usr/bin/k3s-agent agent -t $(<${RANCHER_PATH}/k3s/server/node-token) -s https://${IP}:6443

--- a/scripts/setup-rancher-path.sh
+++ b/scripts/setup-rancher-path.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $(id -u) = 0 ]; then
+    RANCHER_PATH="/var/lib/rancher"
+else
+    RANCHER_PATH="$HOME/.rancher"
+fi


### PR DESCRIPTION
After running the steps in https://github.com/rancher/k3s#building-from-source up to running ```dev-agent.sh```, the node token was in:
```/var/lib/rancher/k3s/server/node-token``` (this VM has never had binary release installed on it)
So changed ```dev-agent.sh``` to reflect this.
Note: I haven't tested change to ```dev-docker-agent.sh``` separately yet and out of time for this evening