### PR TITLE
Enable systemd ready notification for k3s server

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	systemd "github.com/coreos/go-systemd/daemon"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/natefinch/lumberjack"
 	"github.com/pkg/errors"
@@ -99,6 +100,9 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	}
 
 	logrus.Info("Starting k3s ", app.App.Version)
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	os.Unsetenv("NOTIFY_SOCKET")
+
 	ctx := signal.SigTermCancelContext(context.Background())
 	certs, err := server.StartServer(ctx, &serverConfig)
 	if err != nil {
@@ -106,6 +110,10 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	}
 
 	logrus.Info("k3s is up and running")
+	if notifySocket != "" {
+		os.Setenv("NOTIFY_SOCKET", notifySocket)
+		systemd.SdNotify(true, "READY=1")
+	}
 
 	if cfg.DisableAgent {
 		<-ctx.Done()


### PR DESCRIPTION
Disables k8s generic api server systemd ready notification and send
our own ready notification after server available and kubeconfig
available.

Make sure we unset the NOTIFY_SOCKET environment variable by passing
`true` to SdNotify so the agent can start containers.

For rancher/k3s/issues/57