### PR TITLE
Update README for correct VXLAN port

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ Open ports / Network security
 ---------------------------
 
 The server needs port 6443 to be accessible by the nodes.  The nodes need to be able to reach
-other nodes over UDP port 4789.  This is used for flannel VXLAN.  If you don't use flannel
-and provide your own custom CNI, then 4789 is not needed by k3s. The node should not listen
+other nodes over UDP port 8472.  This is used for flannel VXLAN.  If you don't use flannel
+and provide your own custom CNI, then 8472 is not needed by k3s. The node should not listen
 on any other port.  k3s uses reverse tunneling such that the nodes make outbound connections
 to the server and all kubelet traffic runs through that tunnel.
 
 IMPORTANT. The VXLAN port on nodes should not be exposed to the world, it opens up your
 cluster network to accessed by anyone.  Run your nodes behind a firewall/security group that
-disables access to port 4789.
+disables access to port 8472.
 
 
 Server HA


### PR DESCRIPTION
Flannel uses port 8472 for VXLAN: https://github.com/coreos/flannel/blame/e63a71b4de14407d0bee999ffa2f0f68758c34a1/Documentation/backends.md#L23

```
ip -d l show flannel.1
... dstport 8472 ...
```