### PR TITLE
A way to isolate the service and the k3s program (and use config file).

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -54,7 +54,7 @@ func kubelet(cfg *config.Agent) {
 		"--healthz-bind-address", "127.0.0.1",
 		"--read-only-port", "0",
 		"--allow-privileged=true",
-		"--cluster-domain", "cluster.local",
+		"--cluster-domain", "cluster.site",
 		"--kubeconfig", cfg.KubeConfig,
 		"--eviction-hard", "imagefs.available<5%,nodefs.available<5%",
 		"--eviction-minimum-reclaim", "imagefs.available=10%,nodefs.available=10%",


### PR DESCRIPTION
I needed to be able to modify the parameters of the agents (and server) to make tests.

so I created a program that allows me to recover options directly from a yaml file.
(Https://github.com/Sellto/k3s-startup)

I just updated the install.sh file so that it uses my program to control k3s when it is used as a service.
The updates are now effective after a restart of the service.

ToDo
(Build k3s-startup.go in ARM and ARM64 to update the release)