### PR TITLE
Fix not ignoring empty YAML

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -259,6 +259,9 @@ func yamlToObjects(in io.Reader) ([]runtime.Object, error) {
 		if err == io.EOF {
 			break
 		}
+		if bytes.Count(raw, []byte{'\n'}) == len(raw) {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR resolves reported bug (see #222) where including empty YAML specification (i.e. containing only newline character(s)) at the end of file included in the manifests folder causes error.

After the proposed change, the controller first checks whether the YAML specification is empty (i.e. check whether it contains only newlines) and only if this conditions is false would pass the YAML further to next function.