### PR TITLE
Short port names for service load balancer

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -272,11 +272,8 @@ func (h *handler) newDeployment(svc *core.Service) (*apps.Deployment, error) {
 		},
 	}
 
-	for i, port := range svc.Spec.Ports {
-		portName := port.Name
-		if portName == "" {
-			portName = fmt.Sprintf("port-%d", i)
-		}
+	for _, port := range svc.Spec.Ports {
+		portName := fmt.Sprintf("lb-port-%d", port.Port)
 		container := core.Container{
 			Name:            portName,
 			Image:           image,


### PR DESCRIPTION
If a port name is longer than 15 characters we are unable to create
the associated service load balancer containers. Use our own short
name of `lb-port-{port}` to avoid naming issues.

For rancher/k3s/issues/90