### PR TITLE
Add tls-san flag

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -16,6 +16,7 @@ type Server struct {
 	DisableAgent     bool
 	KubeConfigOutput string
 	KubeConfigMode   string
+	AdvertiseAddress string
 }
 
 var ServerConfig Server
@@ -93,6 +94,12 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "Write kubeconfig with this mode",
 				Destination: &ServerConfig.KubeConfigMode,
 				EnvVar:      "K3S_KUBECONFIG_MODE",
+			},
+			cli.StringFlag{
+				Name:        "advertise-address",
+				Usage:       "Advertise address for k3s server",
+				Destination: &ServerConfig.AdvertiseAddress,
+				Value:       "",
 			},
 			NodeIPFlag,
 			NodeNameFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -16,7 +16,7 @@ type Server struct {
 	DisableAgent     bool
 	KubeConfigOutput string
 	KubeConfigMode   string
-	AdvertiseAddress string
+	KnownIPs cli.StringSlice
 }
 
 var ServerConfig Server
@@ -95,11 +95,10 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.KubeConfigMode,
 				EnvVar:      "K3S_KUBECONFIG_MODE",
 			},
-			cli.StringFlag{
-				Name:        "advertise-address",
-				Usage:       "Advertise address for k3s server",
-				Destination: &ServerConfig.AdvertiseAddress,
-				Value:       "",
+			cli.StringSliceFlag{
+				Name:        "tls-san",
+				Usage:       "Add additional hostname or IP as a Subject Alternative Name in the TLS cert",
+				Value: &ServerConfig.KnownIPs,
 			},
 			NodeIPFlag,
 			NodeNameFlag,

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -77,7 +77,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.TLSConfig.HTTPSPort = cfg.HTTPSPort
 	serverConfig.TLSConfig.HTTPPort = cfg.HTTPPort
-	serverConfig.TLSConfig.KnownIPs = knownIPs()
+	serverConfig.TLSConfig.KnownIPs = knownIPs(cfg.AdvertiseAddress)
 
 	_, serverConfig.ControlConfig.ClusterIPRange, err = net2.ParseCIDR(cfg.ClusterCIDR)
 	if err != nil {
@@ -146,13 +146,18 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	return agent.Run(ctx, agentConfig)
 }
 
-func knownIPs() []string {
+func knownIPs(hosts string) []string {
 	ips := []string{
 		"127.0.0.1",
 	}
 	ip, err := net.ChooseHostInterface()
 	if err == nil {
 		ips = append(ips, ip.String())
+	}
+	for _, host := range strings.Split(hosts, ",") {
+		if host != "" {
+			ips = append(ips, host)
+		}
 	}
 	return ips
 }

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -77,7 +77,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.KubeConfigMode = cfg.KubeConfigMode
 	serverConfig.TLSConfig.HTTPSPort = cfg.HTTPSPort
 	serverConfig.TLSConfig.HTTPPort = cfg.HTTPPort
-	serverConfig.TLSConfig.KnownIPs = knownIPs(cfg.AdvertiseAddress)
+	serverConfig.TLSConfig.KnownIPs = knownIPs(cfg.KnownIPs)
 
 	_, serverConfig.ControlConfig.ClusterIPRange, err = net2.ParseCIDR(cfg.ClusterCIDR)
 	if err != nil {
@@ -146,18 +146,11 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	return agent.Run(ctx, agentConfig)
 }
 
-func knownIPs(hosts string) []string {
-	ips := []string{
-		"127.0.0.1",
-	}
+func knownIPs(ips []string) []string {
+	ips = append(ips, "127.0.0.1")
 	ip, err := net.ChooseHostInterface()
 	if err == nil {
 		ips = append(ips, ip.String())
-	}
-	for _, host := range strings.Split(hosts, ",") {
-		if host != "" {
-			ips = append(ips, host)
-		}
 	}
 	return ips
 }


### PR DESCRIPTION
In NAT or LB environment,
we need not just the certs for local ip, but also additional ips.
advertise-address flag enables to add optional ips.

Related: #214 