### PR TITLE
Allow flannel interface to be specified on the command line

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -206,11 +206,20 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 		return nil, errors.Wrapf(err, "failed to find host-local")
 	}
 
+	var flannelIface *sysnet.Interface
+	if !envInfo.NoFlannel && len(envInfo.FlannelIface) > 0 {
+		flannelIface, err = sysnet.InterfaceByName(envInfo.FlannelIface)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to find interface")
+		}
+	}
+
 	nodeConfig := &config.Node{
 		Docker:                   envInfo.Docker,
 		NoFlannel:                envInfo.NoFlannel,
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 	}
+	nodeConfig.FlannelIface = flannelIface
 	nodeConfig.LocalAddress = localAddress(controlConfig)
 	nodeConfig.Images = filepath.Join(envInfo.DataDir, "images")
 	nodeConfig.AgentConfig.NodeIP = nodeIP

--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, config *config.Node) error {
 	}
 
 	go func() {
-		err := flannel(ctx, config.FlannelConf, config.AgentConfig.KubeConfig)
+		err := flannel(ctx, config.FlannelIface, config.FlannelConf, config.AgentConfig.KubeConfig)
 		logrus.Fatalf("flannel exited: %v", err)
 	}()
 

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -19,6 +19,7 @@ type Agent struct {
 	Docker                   bool
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
+	FlannelIface             string
 	Debug                    bool
 	Rootless                 bool
 	AgentShared
@@ -53,6 +54,11 @@ var (
 		Name:        "no-flannel",
 		Usage:       "(agent) Disable embedded flannel",
 		Destination: &AgentConfig.NoFlannel,
+	}
+	FlannelIfaceFlag = cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
 	}
 	CRIEndpointFlag = cli.StringFlag{
 		Name:        "container-runtime-endpoint",
@@ -121,6 +127,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 			},
 			DockerFlag,
 			FlannelFlag,
+			FlannelIfaceFlag,
 			NodeNameFlag,
 			NodeIPFlag,
 			CRIEndpointFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -134,6 +134,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 			NodeNameFlag,
 			DockerFlag,
 			FlannelFlag,
+			FlannelIfaceFlag,
 			CRIEndpointFlag,
 			ResolvConfFlag,
 			ExtraKubeletArgs,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -15,6 +15,7 @@ type Node struct {
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
 	FlannelConf              string
+	FlannelIface             *net.Interface
 	LocalAddress             string
 	Containerd               Containerd
 	Images                   string


### PR DESCRIPTION
This should fix #200 and #72.

I am having issues building this on my local system to test properly as dapper keeps flaking out. I am hoping someone can review this while I try and fix dapper.