### PR TITLE
Generate air-gap image artifacts

### DIFF
--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	namespace = "kube-system"
-	image     = "rancher/klipper-helm:v0.1.4"
+	image     = "rancher/klipper-helm:v0.1.5"
 	label     = "helm.k3s.cattle.io/chart"
 )
 

--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -158,7 +158,7 @@ func job(chart *k3s.HelmChart) (*batch.Job, *core.ConfigMap) {
 						{
 							Name:            "helm",
 							Image:           image,
-							ImagePullPolicy: core.PullAlways,
+							ImagePullPolicy: core.PullIfNotPresent,
 							Args:            args(chart),
 							Env: []core.EnvVar{
 								{

--- a/scripts/airgap/generate-list.sh
+++ b/scripts/airgap/generate-list.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)
+
+k3s crictl images -o json \
+    | jq -r '.images[].repoTags[0] | select(. != null)' \
+    | tee image-list.txt

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,0 +1,5 @@
+docker.io/coredns/coredns:1.3.0
+docker.io/library/traefik:1.7.9
+docker.io/rancher/klipper-helm:v0.1.5
+docker.io/rancher/klipper-lb:v0.1.1
+k8s.gcr.io/pause:3.1

--- a/scripts/package
+++ b/scripts/package
@@ -9,3 +9,4 @@ fi
 
 ./package-cli
 ./package-image
+./package-airgap

--- a/scripts/package-airgap
+++ b/scripts/package-airgap
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e -x
+
+source $(dirname $0)/version.sh
+
+cd $(dirname $0)/..
+
+images=$(cat scripts/airgap/image-list.txt)
+xargs -n1 docker pull <<< "${images}"
+docker save ${images} -o dist/artifacts/k3s-airgap-images-${ARCH}.tar 


### PR DESCRIPTION
Create artifacts for air-gap images and tools for generating new image lists.
Updates klipper-helm for air-gap compatibility.

For rancher/k3s/issues/166