### PR TITLE
Skip writing manifest when using `--no-deploy`

### DIFF
--- a/pkg/deploy/controller.go
+++ b/pkg/deploy/controller.go
@@ -35,14 +35,13 @@ const (
 	startKey = "_start_"
 )
 
-func WatchFiles(ctx context.Context, skips []string, bases ...string) error {
+func WatchFiles(ctx context.Context, bases ...string) error {
 	server := norman.GetServer(ctx)
 	addons := v1.ClientsFrom(ctx).Addon
 
 	w := &watcher{
 		addonCache: addons.Cache(),
 		addons:     addons,
-		skips:      skips,
 		bases:      bases,
 		restConfig: *server.Runtime.LocalConfig,
 		discovery:  server.K8sClient.Discovery(),
@@ -64,7 +63,6 @@ type watcher struct {
 	addonCache v1.AddonClientCache
 	addons     v1.AddonClient
 	bases      []string
-	skips      []string
 	restConfig rest.Config
 	discovery  discovery.DiscoveryInterface
 	clients    map[schema.GroupVersionKind]*objectclient.ObjectClient
@@ -107,9 +105,6 @@ func (w *watcher) listFilesIn(base string, force bool) error {
 	}
 
 	skips := map[string]bool{}
-	for _, skip := range w.skips {
-		skips[skip] = true
-	}
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), ".skip") {
 			skips[strings.TrimSuffix(file.Name(), ".skip")] = true

--- a/pkg/deploy/stage.go
+++ b/pkg/deploy/stage.go
@@ -9,10 +9,18 @@ import (
 	"path/filepath"
 )
 
-func Stage(dataDir string, templateVars map[string]string) error {
+func Stage(dataDir string, templateVars map[string]string, skipList []string) error {
 	os.MkdirAll(dataDir, 0700)
 
+	skips := map[string]bool{}
+	for _, skip := range skipList {
+		skips[skip] = true
+	}
+
 	for _, name := range AssetNames() {
+		if skips[name] {
+			continue
+		}
 		content, err := Asset(name)
 		if err != nil {
 			return err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -126,10 +126,10 @@ func startNorman(ctx context.Context, config *Config) (string, error) {
 			func(ctx context.Context) error {
 				dataDir := filepath.Join(controlConfig.DataDir, "manifests")
 				templateVars := map[string]string{"%{CLUSTER_DNS}%": controlConfig.ClusterDNS.String()}
-				if err := deploy.Stage(dataDir, templateVars); err != nil {
+				if err := deploy.Stage(dataDir, templateVars, controlConfig.Skips); err != nil {
 					return err
 				}
-				if err := deploy.WatchFiles(ctx, controlConfig.Skips, dataDir); err != nil {
+				if err := deploy.WatchFiles(ctx, dataDir); err != nil {
 					return err
 				}
 				return nil


### PR DESCRIPTION
Instead of skipping the manifest when listing the directory, we now skip
creating it in the first place. This allows users to deploy manifests
that replaces the ones bundled, without having to come up with a new
name.

Fixes #230.