### PR TITLE
support custom containerd config for etc/containerd/config.toml

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -58,6 +58,10 @@ func Run(ctx context.Context, cfg *config.Node) error {
 	template = strings.Replace(template, "%CNICFG%", cfg.AgentConfig.CNIConfDir, -1)
 	template = strings.Replace(template, "%NODE%", cfg.AgentConfig.NodeName, -1)
 
+	if os.Getenv("CONTAINERD_CUSTOM_CONFIG") != "" {
+		template += os.Getenv("CONTAINERD_CUSTOM_CONFIG")
+	}
+
 	if err := util2.WriteFile(cfg.Containerd.Config, template); err != nil {
 		return err
 	}


### PR DESCRIPTION
ie:  add private registry mirror
* `export CONTAINERD_CUSTOM_CONFIG="$(cat  containerd_custom.conf)" `

* containerd_custom.conf
```
[plugins.cri.registry.mirrors]
  [plugins.cri.registry.mirrors."docker.io"]
    endpoint = ["https://docker:5000","https://registry-1.docker.io"]
```