### PR TITLE
[WIP] improve ipv6-only cluster function

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -102,6 +102,9 @@ func getHostnameAndIP(info cmds.Agent) (string, string, error) {
 }
 
 func localAddress(controlConfig *config.Control) string {
+	if controlConfig.ClusterIPRange.IP.To4() == nil {
+		return fmt.Sprintf("[::1]:%d", controlConfig.AdvertisePort)
+	}
 	return fmt.Sprintf("127.0.0.1:%d", controlConfig.AdvertisePort)
 }
 

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -433,8 +433,8 @@ func genTLSCerts(config *config.Control, runtime *config.ControlRuntime) error {
 
 	if err := createClientCertKey(regen, "localhost",
 		nil, &certutil.AltNames{
-			DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"},
-			IPs:      []net.IP{apiServerServiceIP, localhostIP},
+			DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost", "ip6-localhost"},
+			IPs:      []net.IP{apiServerServiceIP, localhostIP, net.IPv6loopback},
 		}, x509KeyServerOnly,
 		runtime.TLSCA, runtime.TLSCAKey,
 		runtime.TLSCert, runtime.TLSKey); err != nil {
@@ -457,8 +457,8 @@ func genTokenCerts(config *config.Control, runtime *config.ControlRuntime) error
 
 	if err := createClientCertKey(regen, "kubernetes",
 		nil, &certutil.AltNames{
-			DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"},
-			IPs:      []net.IP{apiServerServiceIP, localhostIP},
+			DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost", "ip6-localhost"},
+			IPs:      []net.IP{apiServerServiceIP, localhostIP, net.IPv6loopback},
 		}, x509KeyClientUsage,
 		runtime.TokenCA, runtime.TokenCAKey,
 		runtime.NodeCert, runtime.NodeKey); err != nil {


### PR DESCRIPTION
This PR is a partial fix for #284 .

This PR adds the ipv6 localhost address `[::1]:6445` to be used on an ipv6-only cluster instead of the ipv4 127.0.0.1.

It also adds the ipv6 localhost `[::1]` to the certificates, both in `genTLS` and `genTokenTLS`. This is done always, even in an ipv4-only cluster. Since it is localhost I did not think there will be any security issues(?).

### Remaining problem

Access to the k8s api does not work from within a pod. The service endpoint for the kubernetes service is;
```
# kubectl get service kubernetes
NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   fd00:4000::1   <none>        443/TCP   2m16s
# kubectl get endpoints kubernetes
NAME         ENDPOINTS    AGE
kubernetes   [::1]:6445   49s
```
which I think is correct but from within a pod it is not possible to connect to the kubernetes service ip (connection hangs). From main netns it works fine.

I am a bit stuck so I publish this PR with hope of aid from others.

