### PR TITLE
Extend systemd start timeout for slow systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Documentation=https://k3s.io
 After=network.target
 
 [Service]
+Type=notify
+EnvironmentFile=/etc/systemd/system/k3s.service.env
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s server
@@ -274,6 +276,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -402,6 +402,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/k3s.service
+++ b/k3s.service
@@ -13,6 +13,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Cert generation may cause slow startup times for some systems such as
the Raspberry Pi, set the systemd service TimeoutStartSec to Infinity to
avoid startup timeouts.

From rancher/k3s/pull/226