### PR TITLE
Ignore proxy settings for kubelet client

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -169,6 +169,7 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 
 	if DefaultProxyDialerFn != nil {
 		completedOptions.KubeletConfig.Dial = DefaultProxyDialerFn
+		completedOptions.KubeletConfig.Proxy = http.ProxyURL(nil)
 	}
 
 	kubeAPIServerConfig, insecureServingInfo, serviceResolver, pluginInitializer, admissionPostStartHook, err := CreateKubeAPIServerConfig(completedOptions, proxyTransport)

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -51,6 +52,9 @@ type KubeletClientConfig struct {
 
 	// Dial is a custom dialer used for the client
 	Dial utilnet.DialFunc
+
+	// Proxy is a custom proxy function for the client
+	Proxy func(*http.Request) (*url.URL, error)
 }
 
 // ConnectionInfo provides the information needed to connect to a kubelet
@@ -77,6 +81,7 @@ func MakeTransport(config *KubeletClientConfig) (http.RoundTripper, error) {
 		rt = utilnet.SetOldTransportDefaults(&http.Transport{
 			DialContext:     config.Dial,
 			TLSClientConfig: tlsConfig,
+			Proxy:           config.Proxy,
 		})
 	}
 


### PR DESCRIPTION
Proxy settings may interfere with a kubelet client communicating with
the API server, so set the proxy to nil.