### PR TITLE
Add --proxy-mode option to allow user choose ipvs or other proxy mode

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -226,6 +226,7 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 	nodeConfig.AgentConfig.NodeName = nodeName
 	nodeConfig.AgentConfig.ClusterDNS = controlConfig.ClusterDNS
 	nodeConfig.AgentConfig.ClusterDomain = controlConfig.ClusterDomain
+	nodeConfig.AgentConfig.ProxyMode = controlConfig.ProxyMode
 	nodeConfig.AgentConfig.ResolvConf = locateOrGenerateResolvConf(envInfo)
 	nodeConfig.AgentConfig.CACertPath = clientCA
 	nodeConfig.AgentConfig.ListenAddress = "127.0.0.1"

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -9,6 +9,7 @@ type Server struct {
 	ClusterCIDR         string
 	ClusterSecret       string
 	ServiceCIDR         string
+	ProxyMode           string
 	ClusterDNS          string
 	ClusterDomain       string
 	HTTPSPort           int
@@ -71,6 +72,12 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "Network CIDR to use for pod IPs",
 				Destination: &ServerConfig.ClusterCIDR,
 				Value:       "10.42.0.0/16",
+			},
+			cli.StringFlag{
+				Name:        "proxy-mode",
+				Usage:       "kube-proxy proxy mode to use",
+				Destination: &ServerConfig.ProxyMode,
+				Value:       "iptables",
 			},
 			cli.StringFlag{
 				Name:        "cluster-secret",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -101,6 +101,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.ExtraControllerArgs = cfg.ExtraControllerArgs
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
 	serverConfig.ControlConfig.ClusterDomain = cfg.ClusterDomain
+	serverConfig.ControlConfig.ProxyMode = cfg.ProxyMode
 
 	_, serverConfig.ControlConfig.ClusterIPRange, err = net2.ParseCIDR(cfg.ClusterCIDR)
 	if err != nil {

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -32,7 +32,7 @@ func Agent(config *config.Agent) error {
 
 func kubeProxy(cfg *config.Agent) {
 	argsMap := map[string]string{
-		"proxy-mode":           "iptables",
+		"proxy-mode":           cfg.ProxyMode,
 		"healthz-bind-address": "127.0.0.1",
 		"kubeconfig":           cfg.KubeConfig,
 		"cluster-cidr":         cfg.ClusterCIDR.String(),

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -37,6 +37,7 @@ type Containerd struct {
 type Agent struct {
 	NodeName           string
 	ClusterCIDR        net.IPNet
+	ProxyMode          string
 	ClusterDNS         net.IP
 	ClusterDomain      string
 	ResolvConf         string
@@ -57,6 +58,7 @@ type Control struct {
 	ListenPort            int
 	ClusterSecret         string
 	ClusterIPRange        *net.IPNet
+	ProxyMode             string
 	ServiceIPRange        *net.IPNet
 	ClusterDNS            net.IP
 	ClusterDomain         string


### PR DESCRIPTION
the default is iptables mode if the option is omitted, use --proxy-node ipvs
for ipvs mode