### PR TITLE
Revert "Use host's mount binary before packaged mount"

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -84,7 +84,7 @@ func stageAndRun(dataDir string, cmd string, args []string) error {
 		return errors.Wrap(err, "extracting data")
 	}
 
-	if err := os.Setenv("PATH", filepath.Join(dir, "bin")+":"+os.Getenv("PATH")+":"+filepath.Join(dir, "bin/aux")); err != nil {
+	if err := os.Setenv("PATH", filepath.Join(dir, "bin")+":"+os.Getenv("PATH")); err != nil {
 		return err
 	}
 

--- a/scripts/download
+++ b/scripts/download
@@ -12,7 +12,6 @@ mkdir -p ${CHARTS_DIR}
 
 curl --compressed -sfL https://github.com/ibuildthecloud/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
 ln -sf pigz bin/unpigz
-mkdir -p bin/aux && rm bin/mount && ln -sf ../busybox bin/aux/mount
 
 TRAEFIK_FILE=traefik-${TRAEFIK_VERSION}.tgz
 curl -sfL https://kubernetes-charts.storage.googleapis.com/${TRAEFIK_FILE} -o ${CHARTS_DIR}/${TRAEFIK_FILE}


### PR DESCRIPTION
This reverts commit e2ecb672db934dc1f395460cbcacf8531a2f38f8.

Revert because moving the mount binary causes issue with docker setup