### PR TITLE
Fix typo and add kubeconfig copy to user homedir

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -1,6 +1,6 @@
 # Build a Kubernetes cluster using k3s via Ansible.
 
-https://github.com/itwars
+Author: https://github.com/itwars
 
 ## K3s Ansible Playbook
 

--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -1,5 +1,7 @@
 # Build a Kubernetes cluster using k3s via Ansible.
 
+https://github.com/itwars
+
 ## K3s Ansible Playbook
 
 Build a Kubernetes cluster using Ansible with k3s. The goal is easily install a Kubernetes cluster on machines running:
@@ -38,6 +40,9 @@ node
 Start provisioning of the cluster using the following command:
 
 ```
-ansible-playbook site.yaml
+ansible-playbook site.yml
 ```
 
+## Kubeconfig
+
+To get access to your **Kubernetes** cluster just scp debian@master_pi:~/kube/config ~/.kube/config

--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -16,7 +16,7 @@
     state: restarted
     enabled: yes
 
-- name: Register file access mode
+- name: Register node-token file access mode
   stat:
     path: /var/lib/rancher/k3s/server
   register: p
@@ -26,18 +26,35 @@
     path: /var/lib/rancher/k3s/server
     mode: "g+rx,o+rx"
 
-- name: Read Node Token from Master
+- name: Read node-token from master
   slurp:
     src: /var/lib/rancher/k3s/server/node-token
   register: node_token
 
-- name: Store Master Token
+- name: Store Master node-token
   set_fact: 
    token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
 
-- name: Restore file access 
+- name: Restore node-token file access 
   file:
     path: /var/lib/rancher/k3s/server
     mode: "{{ p.stat.mode }}"
 
-#- debug: msg="Node TOKEN {{ token }}"
+- name: Create directory .kube
+  file:
+    path: /home/{{ ansible_user }}/.kube
+    state: directory
+    owner: "{{ ansible_user }}"
+
+- name: Copy config file to user home directory
+  copy:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: /home/{{ ansible_user }}/.kube/config
+    remote_src: yes
+    owner: "{{ ansible_user }}"
+
+- name: Replace https://localhost:6443 by https://master-pi:6443
+  replace:
+    path: /home/{{ ansible_user }}/.kube/config
+    regexp: 'https://localhost:6443'
+    replace: 'https://{{master_ip}}:6443'


### PR DESCRIPTION
I've enhance some Ansible display informations, and add the automatic copy of kubeconfig file to user home directory in ~/.kube/config. In addition https://localhost:6443 is replace by https://master_ip:6443 in order to easily make an scp on your laptop.
