### PR TITLE
Ansible: Test for Raspbian before assuming

### DIFF
--- a/contrib/ansible/roles/raspbian/tasks/main.yml
+++ b/contrib/ansible/roles/raspbian/tasks/main.yml
@@ -1,14 +1,24 @@
 ---
 
+- name: Test for Raspbian
+  stat:
+    path: /boot/cmdline.txt
+  register: cmdline
+
 - name: Activating cgroup on Raspbian
   lineinfile:
     path: /boot/cmdline.txt
     regexp: '^(.*rootwait)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  when: ( ansible_facts.architecture is search "arm" )
+  when: ( cmdline.stat.path is defined )
+          and
+        ( ansible_facts.architecture is search("arm") )
+  register: boot_cmdline
 
 - name: Rebooting on Raspbian 
   shell: reboot now
   ignore_errors: true
-  when: ( ansible_facts.architecture is search "arm" )
+  when: ( boot_cmdline | changed )
+          and
+        ( ansible_facts.architecture is search("arm") )


### PR DESCRIPTION
## What's changing

Adds a test for the Raspbian OS -specific file before assuming file can be modified.

## Why

Currently the role assumes `/boot/cmdline.txt` file exists.
On other ARM OS's (Armbian) it does not, nor does it need editing.
