### PR TITLE
contrib/ansible: Allow 'server' and 'node' roles to co-exist on a single host

### DIFF
--- a/contrib/ansible/roles/k3s/node/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/node/tasks/main.yml
@@ -3,14 +3,14 @@
 - name: Copy K3s service file
   template:
     src: "k3s.service.j2"
-    dest: "{{ systemd_dir }}/k3s.service"
+    dest: "{{ systemd_dir }}/k3s-node.service"
     owner: root
     group: root
     mode: 0755
 
 - name: Enable and check K3s service
   systemd:
-    name: k3s
+    name: k3s-node
     daemon_reload: yes
     state: restarted
     enabled: yes


### PR DESCRIPTION
## What's changing

Instead of using a common filename for the systemd unit file in two different ansible roles, this PR separates the unit file name into two unique filenames:
- one for the `server` role (`/etc/systemd/system/k3s.service`)
- one for the `node` role (`/etc/systemd/system/k3s-node.service`)

## Why
Currently, when attempting to install both the `server` and `node` ansible roles on the same host, the `node` role would overwrite the `server` role's systemd file because it was installed to the same path.
