### PR TITLE
contrib/ansible: Fixes 'search' test usage syntax

### DIFF
--- a/contrib/ansible/roles/download/tasks/main.yml
+++ b/contrib/ansible/roles/download/tasks/main.yml
@@ -6,7 +6,7 @@
     state: absent
 
 - name: Download k3s binary x64
-  get_url:                                                           
+  get_url:
       url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s
       dest: /usr/local/bin/k3s
       owner: root
@@ -16,21 +16,23 @@
   when: ( ansible_facts.architecture == "x86_64" )
 
 - name: Download k3s binary arm64
-  get_url:                                                           
+  get_url:
       url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-arm64
       dest: /usr/local/bin/k3s
       owner: root
       group: root
       mode: 755
-  when: ( ansible_facts.architecture is search "arm" and 
-          ansible_facts.userspace_bits == "64" )
+  when: ( ansible_facts.architecture is search("arm") )
+          and
+        ( ansible_facts.userspace_bits == "64" )
 
 - name: Download k3s binary armhf
-  get_url:                                                           
+  get_url:
       url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-armhf
       dest: /usr/local/bin/k3s
       owner: root
       group: root
       mode: 755
-  when: ( ansible_facts.architecture is search "arm" and 
-          ansible_facts.userspace_bits == "32" )
+  when: ( ansible_facts.architecture is search("arm") )
+          and
+        ( ansible_facts.userspace_bits == "32" )


### PR DESCRIPTION
existing usage produced an error under ansible 2.6.1