### PR TITLE
feat: expose Traefik LoadBalancer IP on Ingresses by default

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -8,3 +8,4 @@ spec:
   set:
     rbac.enabled: "true"
     ssl.enabled: "true"
+    kubernetes.ingressEndpoint.useDefaultPublishedService: "true"


### PR DESCRIPTION
Configure Traefik to update the Ingress Resources `loadBalancer` status.

This would provide users with the following benefits:

1. It drastically simplifies the way one can quickly determine the relevant IP for a certain Ingress Resource, without needing to know how or where the LoadBalancer comes from.
2. Assuming a User that has no permission to *list* or *read* services from the `kube-system` namespace, for such a User this change would basically empower them to access the relevant information without being bottlenecked by another.
3. Allow tools like [external-dns](https://github.com/kubernetes-incubator/external-dns) to dynamically register all the available Ingress Resources with one of the Supported DNS Providers such as a local [CoreDNS](https://coredns.io) for easier access to hosted services. Effectively removing the need to first lookup the LoadBalancer IP (if permitted, see 2.) and running `curl --header 'Host: www.example.com' <IP of k3s LoadBalancer>`.