### PR TITLE
rootless: fix mounting /var/lib/cni

### DIFF
--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -42,13 +42,17 @@ func setupMount(target, dir string) error {
 		toCreate = filepath.Base(toCreate)
 	}
 
+	if err := os.MkdirAll(toCreate, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create directory %s", toCreate)
+	}
+
 	logrus.Debug("Mounting none ", toCreate, " tmpfs")
 	if err := unix.Mount("none", toCreate, "tmpfs", 0, ""); err != nil {
 		return errors.Wrapf(err, "failed to mount tmpfs to %s", toCreate)
 	}
 
 	if err := os.MkdirAll(target, 0700); err != nil {
-		return errors.Wrapf(err, "failed to create directory %s")
+		return errors.Wrapf(err, "failed to create directory %s", target)
 	}
 
 	if dir == "" {
@@ -56,7 +60,7 @@ func setupMount(target, dir string) error {
 	}
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		return errors.Wrapf(err, "failed to create directory %s")
+		return errors.Wrapf(err, "failed to create directory %s", dir)
 	}
 
 	logrus.Debug("Mounting ", dir, target, " none bind")

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -128,7 +128,7 @@ func createChildOpt() (*child.Opt, error) {
 	opt.PipeFDEnvKey = pipeFD
 	opt.NetworkDriver = slirp4netns.NewChildDriver()
 	opt.PortDriver = portbuiltin.NewChildDriver(&logrusDebugWriter{})
-	opt.CopyUpDirs = []string{"/etc", "/run"}
+	opt.CopyUpDirs = []string{"/etc", "/run", "/var/lib"}
 	opt.CopyUpDriver = tmpfssymlink.NewChildDriver()
 	return opt, nil
 }


### PR DESCRIPTION
k3s was unable to start up when /var/lib/cni is missing on the host.

Fix https://github.com/rancher/k3s/issues/470

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>