### PR TITLE
Fix an inconsistency in contrib/ansible/README.md

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -32,7 +32,7 @@ Add the system information gathered above into a file called hosts.ini. For exam
 [node]
 192.16.35.[10:11]
 
-[kube-cluster:children]
+[k3s-cluster:children]
 master
 node
 ```


### PR DESCRIPTION
The example inventory uses the group `kube-cluster`, but the playbooks reference `k3s-cluster`. This resolves the inconsistency.