### PR TITLE
Don't overwrite flannel config if it exists

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -2,6 +2,7 @@ package flannel
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -98,6 +99,9 @@ func createFlannelConf(config *config.Node) error {
 	if config.FlannelConf == "" {
 		return nil
 	}
-	return util.WriteFile(config.FlannelConf,
-		strings.Replace(netJSON, "%CIDR%", config.AgentConfig.ClusterCIDR.String(), -1))
+	if _, err := os.Stat(config.FlannelConf); os.IsNotExist(err) {
+		return util.WriteFile(config.FlannelConf,
+			strings.Replace(netJSON, "%CIDR%", config.AgentConfig.ClusterCIDR.String(), -1))
+	}
+	return nil
 }


### PR DESCRIPTION
This change made it convenient for me to tweak the automatically generated flannel config file for testing purposes. Overwriting the file on every startup does not seem necessary, if this breaks something else, I have not run into it.

re: #538 