### PR TITLE
Update to dapper v0.4.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.4.2
   commands:
   - dapper ci
   volumes:
@@ -56,7 +56,7 @@ steps:
     - tag
 
 - name: sonobuoy-e2e-tests
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.4.2
   commands:
   - dapper -f Dockerfile.sonobuoy.dapper
   volumes:
@@ -95,7 +95,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.4.2
   commands:
   - dapper ci
   volumes:
@@ -157,7 +157,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.4.2
   commands:
   - dapper ci
   volumes:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGETS := $(shell ls scripts | grep -v \\.sh)
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/v0.4.2/dapper-`uname -s`-`uname -m` > .dapper.tmp
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper


### PR DESCRIPTION
This will add support for building k3s w/ dapper using buildkit.

Related: https://github.com/rancher/k3s/issues/504