### PR TITLE
Add wait for node-token file

### DIFF
--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -16,6 +16,10 @@
     state: restarted
     enabled: yes
 
+- name: Wait for node-token
+  wait_for:
+    path: /var/lib/rancher/k3s/server/node-token
+
 - name: Register node-token file access mode
   stat:
     path: /var/lib/rancher/k3s/server


### PR DESCRIPTION
Running the ansible playbook on a raspberry pi cluster causes the following error:

```bash
PLAY [master] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************
Sunday 07 July 2019  11:50:54 +0000 (0:00:01.347)       0:02:33.074 ***********
ok: [192.168.1.110]

TASK [k3s/master : Copy K3s service file] *****************************************************************************************************************************************************
Sunday 07 July 2019  11:50:59 +0000 (0:00:05.167)       0:02:38.243 ***********
ok: [192.168.1.110]

TASK [k3s/master : Enable and check K3s service] **********************************************************************************************************************************************
Sunday 07 July 2019  11:51:03 +0000 (0:00:03.494)       0:02:41.737 ***********
changed: [192.168.1.110]

TASK [k3s/master : Register node-token file access mode] **************************************************************************************************************************************
Sunday 07 July 2019  11:51:10 +0000 (0:00:07.340)       0:02:49.078 ***********
ok: [192.168.1.110]

TASK [k3s/master : Change file access node-token] *********************************************************************************************************************************************
Sunday 07 July 2019  11:51:12 +0000 (0:00:01.966)       0:02:51.045 ***********
fatal: [192.168.1.110]: FAILED! => {"changed": false, "msg": "file (/var/lib/rancher/k3s/server) is absent, cannot continue", "path": "/var/lib/rancher/k3s/server"}
```

Looks like the file takes a while to be created and the ansible playbook assumes that the file will be available immediately after the service starts.

Adding a wait task, that will wait for the file to be created resolved the error:

```bash
PLAY [master] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************
Sunday 07 July 2019  11:59:55 +0000 (0:00:01.342)       0:02:58.553 ***********
ok: [192.168.1.110]

TASK [k3s/master : Copy K3s service file] *****************************************************************************************************************************************************
Sunday 07 July 2019  12:00:00 +0000 (0:00:05.182)       0:03:03.736 ***********
ok: [192.168.1.110]

TASK [k3s/master : Enable and check K3s service] **********************************************************************************************************************************************
Sunday 07 July 2019  12:00:03 +0000 (0:00:03.503)       0:03:07.240 ***********
changed: [192.168.1.110]

TASK [k3s/master : Wait for token] ************************************************************************************************************************************************************
Sunday 07 July 2019  12:00:11 +0000 (0:00:07.388)       0:03:14.628 ***********
ok: [192.168.1.110]

TASK [k3s/master : Register node-token file access mode] **************************************************************************************************************************************
Sunday 07 July 2019  12:00:58 +0000 (0:00:47.713)       0:04:02.342 ***********
ok: [192.168.1.110]

TASK [k3s/master : Change file access node-token] *********************************************************************************************************************************************
Sunday 07 July 2019  12:01:01 +0000 (0:00:02.203)       0:04:04.545 ***********
changed: [192.168.1.110]
```