### PR TITLE
Create symlinks for kubectl and crictl

### DIFF
--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -62,3 +62,15 @@
     path: /home/{{ ansible_user }}/.kube/config
     regexp: 'https://localhost:6443'
     replace: 'https://{{master_ip}}:6443'
+
+- name: Create kubectl symlink
+  file:
+    src: /usr/local/bin/k3s
+    dest: /usr/local/bin/kubectl
+    state: link
+
+- name: Create crictl symlink
+  file:
+    src: /usr/local/bin/k3s
+    dest: /usr/local/bin/crictl
+    state: link


### PR DESCRIPTION
Create symlinks for kubectl and crictl.

This avoids you having to use k3s kubectl or k3s crictl. 