### PR TITLE
Fix tunnel endpoint upgrade

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -47,7 +47,7 @@ func run(ctx context.Context, cfg cmds.Agent) error {
 		return err
 	}
 
-	if err := tunnel.Setup(nodeConfig); err != nil {
+	if err := tunnel.Setup(ctx, nodeConfig); err != nil {
 		return err
 	}
 

--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -83,7 +83,6 @@ func Setup(config *config.Node) error {
 			disconnect[address] = connect(wg, address, config, transportConfig)
 		}
 	}
-	wg.Wait()
 
 	go func() {
 	connect:
@@ -134,6 +133,8 @@ func Setup(config *config.Node) error {
 		}
 	}()
 
+	wg.Wait()
+
 	return nil
 }
 
@@ -178,6 +179,9 @@ func connect(waitGroup *sync.WaitGroup, address string, config *config.Node, tra
 			})
 
 			if ctx.Err() != nil {
+				if waitGroup != nil {
+					once.Do(waitGroup.Done)
+				}
 				logrus.Infof("Stopped tunnel to %s", wsURL)
 				return
 			}


### PR DESCRIPTION
If the k8s endpoint changes (eg 127.0.0.1 -> node ip) and we start
an agent during that time, the agent will get stuck waiting to connect
the tunnel to the old ip.  If the agent service is restarted the original
process never exits as it is still waiting to connect, but a new agent
process is created, resulting in multiple agents.

To fix we start waiting after watching for endpoint changes, when the
old ip is removed we also stop waiting for that connection attempt.
Additionally we pass in the context for tunnel connection, so if the
service is terminated we exit immediately instead of continuing to wait
for connections to be established.