### PR TITLE
Add a little extra delay between restart attempts

### DIFF
--- a/contrib/ansible/roles/k3s/master/templates/k3s.service.j2
+++ b/contrib/ansible/roles/k3s/master/templates/k3s.service.j2
@@ -13,6 +13,7 @@ LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
+++ b/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
@@ -11,5 +11,7 @@ LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
 Restart=always
+RestartSec=5s
+
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -527,6 +527,7 @@ LimitCORE=infinity
 TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/k3s.service
+++ b/k3s.service
@@ -15,6 +15,7 @@ LimitCORE=infinity
 TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This extra delay prevents systemd from determining that the service is restarting "too quickly".

At least on the RPi 4, with a wireless connection, it can take a bit longer after the network-online.target is reached before networking is actually ready.  If k3s attempts to start during this time, it exits with the following error:

```
Jul 22 22:57:40 k3s-node01 k3s[476]: time="2019-07-22T22:57:40.220062513+01:00" level=fatal msg="apiserver exited: unable to find suitable network address.error='no default routes found in \"/proc/net/route\" or \"/proc/net/ipv6_route\"'. Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this"
```

Adding a little extra delay prevents the k3s service from hitting the "5 restarts in 10 seconds" and allows systemd to continue to attempt to restart the service while the wireless connection finishes coming up.