### PR TITLE
Appease kubelet warnings on docker for mac

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -176,6 +176,8 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 				i := strings.LastIndex(last, ".slice")
 				if i > 0 {
 					root = "/systemd" + last[:i+len(".slice")]
+				} else {
+					root = "/systemd"
 				}
 			}
 		}


### PR DESCRIPTION
On my environment, the name=systemd entry in /proc/self/cgroup
looks like:

	13:name=systemd:/docker/917b388b40c70b17a3283d852d38bfcdc84d1bf8242e32a779eacd98a610e499

Kubelet periodically complains like:

	E0802 06:42:52.667123       1 summary_sys_containers.go:47] Failed to get system container stats for "/docker/917b388b40c70b17a3283d852d38bfcdc84d1bf8242e32a779eacd98a610e499/kube-proxy": failed to get cgroup stats for "/docker/917b388b40c70b17a3283d852d38bfcdc84d1bf8242e32a779eacd98a610e499/kube-proxy": failed to get container info for "/docker/917b388b40c70b17a3283d852d38bfcdc84d1bf8242e32a779eacd98a610e499/kube-proxy": unknown container "/docker/917b388b40c70b17a3283d852d38bfcdc84d1bf8242e32a779eacd98a610e499/kube-proxy"