### PR TITLE
Fix logging for openrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -565,6 +565,9 @@ command="${BIN_DIR}/k3s"
 command_args="$(escape_dq "${CMD_K3S_EXEC}")
     >>${LOG_FILE} 2>&1"
 
+output_log="${LOG_FILE}"
+error_log="${LOG_FILE}"
+
 pidfile="/var/run/${SYSTEM_NAME}.pid"
 respawn_delay=5
 


### PR DESCRIPTION
Fix logging for Alpine 3.10, openrc --version
openrc (OpenRC) 0.41.2.6fc2696f3e