### PR TITLE
install.sh: Use -eq instead of = for integer comparison

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,7 @@ setup_env() {
 
     # --- use sudo if we are not already root ---
     SUDO=sudo
-    if [ `id -u` = 0 ]; then
+    if [ `id -u` -eq 0 ]; then
         SUDO=
     fi
 
@@ -397,7 +397,7 @@ create_killall() {
     $SUDO tee ${BIN_DIR}/${KILLALL_K3S_SH} >/dev/null << \EOF
 #!/bin/sh
 set -x
-[ `id -u` = 0 ] || exec sudo $0 $@
+[ `id -u` -eq 0 ] || exec sudo $0 $@
 
 for bin in /var/lib/rancher/k3s/data/**/bin/; do
     [ -d $bin ] && export PATH=$bin:$PATH
@@ -453,7 +453,7 @@ create_uninstall() {
     $SUDO tee ${BIN_DIR}/${UNINSTALL_K3S_SH} >/dev/null << EOF
 #!/bin/sh
 set -x
-[ \`id -u\` = 0 ] || exec sudo \$0 \$@
+[ \`id -u\` -eq 0 ] || exec sudo \$0 \$@
 
 ${BIN_DIR}/${KILLALL_K3S_SH}
 


### PR DESCRIPTION
For integer comparison, it is recommended to use '-eq' instead of the
broader comparison '='. From the manual:

n1 -eq n2  True if the integers n1 and n2 are algebraically equal.
s1 = s2    True if the strings s1 and s2 are identical.

Change-Id: I3a92c3944a19e7a618438a9e3e304d9de5d9874f
Signed-off-by: Joakim Roubert <joakimr@axis.com>