### PR TITLE
Changed SELinux/semanage error to fatal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -344,7 +344,7 @@ setup_binary() {
                 fi
                 $SUDO restorecon -v ${BIN_DIR}/k3s > /dev/null
             else
-                error 'SELinux is enabled but semanage is not found'
+                fatal 'SELinux is enabled but semanage is not found'
             fi
         fi
     fi


### PR DESCRIPTION
If the install errors out on semanage not found, an error is
thrown as a 'file not found' for `error`. Updating to 'fatal' resolves
this as the script then exits as intended and throws an 'error'.

Actual output (before):
`sh: line 347: error: command not found`

Output (after):
`[ERROR] SELinux is enabled but semanage is not found`
