### PR TITLE
install.sh: fix openrc service depend in heredoc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -555,8 +555,7 @@ create_openrc_service_file() {
 #!/sbin/openrc-run
 
 depend() {
-    after net-online
-    need net
+    after network-online
 }
 
 start_pre() {


### PR DESCRIPTION
This change sets up the correct dependency on the `network-online` service provided by openrc.

See:
- https://github.com/OpenRC/openrc/blob/0.39.2/service-script-guide.md#be-wary-of-need-net-dependencies
- https://github.com/OpenRC/openrc/blob/0.39.2/init.d/net-online.in#L18
