### PR TITLE
Add comma-separated no-deploy values

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -132,7 +132,14 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		serverConfig.ControlConfig.DefaultLocalStoragePath = cfg.DefaultLocalStoragePath
 	}
 
+	noDeploys := make([]string, 0)
 	for _, noDeploy := range app.StringSlice("no-deploy") {
+		for _, splitNoDeploy := range strings.Split(noDeploy, ",") {
+			noDeploys = append(noDeploys, splitNoDeploy)
+		}
+	}
+
+	for _, noDeploy := range noDeploys {
 		if noDeploy == "servicelb" {
 			serverConfig.DisableServiceLB = true
 			continue


### PR DESCRIPTION
This allows no-deploy values to be either specified as multiple `--no-deploy` invocations, or a single invocation with comma-separated values.