### PR TITLE
CentOS/RHEL compatibility for Ansible roles

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -8,7 +8,7 @@ Build a Kubernetes cluster using Ansible with k3s. The goal is easily install a 
 
 - [X] Debian 
 - [ ] Ubuntu 
-- [ ] CentOS 
+- [X] CentOS 
 
 on processor architecture:
 

--- a/contrib/ansible/roles/prereq/tasks/main.yml
+++ b/contrib/ansible/roles/prereq/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Set SELinux to disabled state
+  selinux:
+    state: disabled
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
+ - name: Enable IPv4 forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    state: present
+    reload: yes
+
+ - name: Enable IPv6 forwarding
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: "1"
+    state: present
+    reload: yes
+
+ - name: Set bridge-nf-call-iptables (just to be sure)
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: "1"
+    state: present
+    reload: yes
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
+ - name: Set bridge-nf-call-ip6tables (just to be sure)
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: "1"
+    state: present
+    reload: yes
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'

--- a/contrib/ansible/site.yml
+++ b/contrib/ansible/site.yml
@@ -4,6 +4,7 @@
   gather_facts: yes
   become: yes
   roles:
+    - { role: prereq }
     - { role: download }
     - { role: raspbian }
 


### PR DESCRIPTION
- Setting IPv4 & IPv6 forwarding
- Setting `sysctl:net.bridge.bridge-nf-call-iptables` and `bridge-nf-call-ip6tables` to enabled since it is disabled by default on some CentOS systems