### PR TITLE
Fix Ansible indentation

### DIFF
--- a/contrib/ansible/roles/prereq/tasks/main.yml
+++ b/contrib/ansible/roles/prereq/tasks/main.yml
@@ -4,21 +4,21 @@
     state: disabled
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
- - name: Enable IPv4 forwarding
+- name: Enable IPv4 forwarding
   sysctl:
     name: net.ipv4.ip_forward
     value: "1"
     state: present
     reload: yes
 
- - name: Enable IPv6 forwarding
+- name: Enable IPv6 forwarding
   sysctl:
     name: net.ipv6.conf.all.forwarding
     value: "1"
     state: present
     reload: yes
 
- - name: Set bridge-nf-call-iptables (just to be sure)
+- name: Set bridge-nf-call-iptables (just to be sure)
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
     value: "1"
@@ -26,7 +26,7 @@
     reload: yes
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
- - name: Set bridge-nf-call-ip6tables (just to be sure)
+- name: Set bridge-nf-call-ip6tables (just to be sure)
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
     value: "1"


### PR DESCRIPTION
This PR fixes an issue with indentation in the contrib Ansible role `prereq`

Error this fixes:

```
ERROR! Syntax Error while loading YAML.
  did not find expected '-' indicator

The error appears to have been in 'k3s/contrib/ansible/roles/prereq/tasks/main.yml': line 7, column 2, but may
be elsewhere in the file depending on the exact syntax problem.
```