### PR TITLE
Node password cleanup

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -26,6 +26,7 @@ type Agent struct {
 	Debug                    bool
 	Rootless                 bool
 	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
 	AgentShared
 	ExtraKubeletArgs   cli.StringSlice
 	ExtraKubeProxyArgs cli.StringSlice
@@ -56,6 +57,11 @@ var (
 		Usage:       "(agent/node) Node name",
 		EnvVar:      "K3S_NODE_NAME",
 		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
 	}
 	DockerFlag = cli.BoolFlag{
 		Name:        "docker",

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -210,6 +210,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.DisableNPC,
 			},
 			NodeNameFlag,
+			WithNodeIDFlag,
 			NodeLabels,
 			NodeTaints,
 			DockerFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -48,6 +48,7 @@ type Containerd struct {
 
 type Agent struct {
 	NodeName                string
+	NodeConfigPath          string
 	ServingKubeletCert      string
 	ServingKubeletKey       string
 	ClusterCIDR             net.IPNet

--- a/pkg/passwd/passwd.go
+++ b/pkg/passwd/passwd.go
@@ -44,8 +44,8 @@ func Read(file string) (*Passwd, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(record) < 3 {
-			return nil, fmt.Errorf("password file '%s' must have at least 3 columns (password, user name, user uid), found %d", file, len(record))
+		if len(record) < 2 {
+			return nil, fmt.Errorf("password file '%s' must have at least 2 columns (password, name), found %d", file, len(record))
 		}
 		e := entry{
 			pass: record[0],


### PR DESCRIPTION
Sets `--hostname-override` flag for kube-proxy.

Store node password in `/etc/rancher/node/password`, so it will survive an 
uninstall and less likely for server to reject node on re-install.

Provide a `--with-node-id` flag to append random id to node name.
