### PR TITLE
make checkCgroups more applicable

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -183,7 +183,7 @@ func checkCgroups() (root string, hasCFS bool, hasPIDs bool) {
 			if system == "pids" {
 				hasPIDs = true
 			} else if system == "cpu" {
-				p := filepath.Join("/sys/fs/cgroup", parts[1], parts[2], "cpu.cfs_period_us")
+				p := filepath.Join("/sys/fs/cgroup", system, parts[2], "cpu.cfs_period_us")
 				if _, err := os.Stat(p); err == nil {
 					hasCFS = true
 				}


### PR DESCRIPTION
As mentioned in #392 , [checkCgroups](https://github.com/rancher/k3s/blob/master/pkg/daemons/agent/agent.go#L168) return wrong flag `hasCFS` when kernel  is 3.10.0.  Check `/sys/fs/cgroup/cpu` may be more applicable.