### PR TITLE
Revert check-config's "Silence modprobe warnings"

### DIFF
--- a/contrib/util/check-config.sh
+++ b/contrib/util/check-config.sh
@@ -270,7 +270,7 @@ echo
 
 SUDO=
 [ $(id -u) -ne 0 ] && SUDO=sudo
-lsmod | grep -q configs || $SUDO modprobe configs >/dev/null 2>&1 || true
+lsmod | grep -q configs || $SUDO modprobe configs || true
 
 if [ -z "$CONFIG" ]; then
   for tryConfig in ${possibleConfigs}; do


### PR DESCRIPTION
This reverts commit 8edbe30c8c3a516a2febc7e4c6edb34867aab435.