### PR TITLE
Update base pause image to rancher repo

### DIFF
--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -29,6 +29,8 @@ const ContainerdConfigTemplate = `
 
 {{- if .NodeConfig.AgentConfig.PauseImage }}
   sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
+{{else}}
+  sandbox_image = "docker.io/rancher/pause:3.1"
 {{end}}
 
 {{- if not .NodeConfig.NoFlannel }}

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -4,4 +4,4 @@ docker.io/rancher/klipper-helm:v0.1.5
 docker.io/rancher/klipper-lb:v0.1.2
 docker.io/rancher/local-path-provisioner:v0.0.11
 docker.io/rancher/metrics-server:v0.3.6
-k8s.gcr.io/pause:3.1
+docker.io/rancher/pause:3.1


### PR DESCRIPTION
**Problem:**
base pause image `gcr.io/pause:3.1` can not be accessed with the block of GFW.

**Solution:**
set the default pause image to `docker.io/rancher/pause:3.1`

**Related Issue:**
https://github.com/rancher/k3s/issues/1128