### PR TITLE
Mutable --node-label values for server/agent sub-commands.

### DIFF
--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -123,7 +123,7 @@ var (
 	}
 	NodeLabels = cli.StringSliceFlag{
 		Name:  "node-label",
-		Usage: "(agent/node) Registering kubelet with set of labels",
+		Usage: "(agent/node) Registering and starting kubelet with set of labels",
 		Value: &AgentConfig.Labels,
 	}
 )


### PR DESCRIPTION
Values passed in via the server/agent `--node-label` flag are treated as mutable. They are passed through to the kubelet just as before (registration-time) but after the kubelet comes up they are applied again. This allows for passing labels a k3s start-time that may be necessary for scheduling but may change from boot to boot, e.g. `k3os.io/version` after an upgrade.

Tested locally on my amd64 workstation with the docker container.

Addresses #1119.