### PR TITLE
Update README.md: k3s does not exclude legacy/alpha/non-default features anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ What is this?
 
 k3s is intended to be a fully compliant Kubernetes distribution with the following changes:
 
-1. Legacy, alpha, non-default features are removed. Hopefully, you shouldn't notice the
-   stuff that has been removed.
-2. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
+1. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
    with out of tree addons.
-3. Add sqlite3 as the default storage mechanism. etcd3 is still available, but not the default.
-4. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
-5. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required
+2. Add sqlite3 as the default storage mechanism. etcd3 is still available, but not the default.
+3. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
+4. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required
    dependencies
     * containerd
     * Flannel


### PR DESCRIPTION
In the past, yes k3s did exclude all those legacy, alpha, non-default features from Kubernetes source as you can see in https://github.com/rancher/k3s/pull/113. But not anymore.

As you can see in the source code, most of legacy/alpha/non-default features is available in k3s, and misleading README should be updated.

But please, don't get me wrong. I'm actually glad to see those features enabled in k3s. :)

#### Reference:
- https://github.com/kubernetes/kubernetes/compare/v1.16.3...rancher:v1.16.3-k3s.1