### PR TITLE
Respect IPv6 when building proxy address

### DIFF
--- a/pkg/agent/tunnel/tunnel.go
+++ b/pkg/agent/tunnel/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -37,14 +38,13 @@ func getAddresses(endpoint *v1.Endpoints) []string {
 	for _, subset := range endpoint.Subsets {
 		var port string
 		if len(subset.Ports) > 0 {
-			port = fmt.Sprint(subset.Ports[0].Port)
+			port = strconv.Itoa(int(subset.Ports[0].Port))
+		}
+		if port == "" {
+			port = "443"
 		}
 		for _, address := range subset.Addresses {
-			serverAddress := address.IP
-			if port != "" {
-				serverAddress += ":" + port
-			}
-			serverAddresses = append(serverAddresses, serverAddress)
+			serverAddresses = append(serverAddresses, net.JoinHostPort(address.IP, port))
 		}
 	}
 	return serverAddresses


### PR DESCRIPTION
I've noticed the following error in k3s logs when running k3s-server on a dual-stack PI cluster:

```
Dec 14 20:46:19 pi-1 k3s[25744]: time="2019-12-14T20:46:19.558820515+01:00" level=info msg="Connecting to proxy" url="wss://192.168.10.14:6443/v1-k3s/connect"
Dec 14 20:46:19 pi-1 k3s[25744]: time="2019-12-14T20:46:19.558829570+01:00" level=info msg="Connecting to proxy" url="wss://2a02:8109:9ac0:36b5:e81b:0:c0a8:a0e:6443/v1-k3s/connect"
Dec 14 20:46:19 pi-1 k3s[25744]: time="2019-12-14T20:46:19.560311466+01:00" level=error msg="Failed to connect to proxy" error="dial tcp: address 2a02:8109:9ac0:36b5:e81b:0:c0a8:a0e:6443: too many colons in address"
Dec 14 20:46:19 pi-1 k3s[25744]: time="2019-12-14T20:46:19.560364280+01:00" level=error msg="Remotedialer proxy error" error="dial tcp: address 2a02:8109:9ac0:36b5:e81b:0:c0a8:a0e:6443: too many colons in address"
```

It doesn't break anything, as the IPv6 address returned from `kube-apiserver` on start and is excluded from the list during k3s-server start process. But it might be worth fixing it as a part of adding IPv6 support