### PR TITLE
Update v1.0 release with containerd patch 3889

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 	github.com/containerd/btrfs => github.com/containerd/btrfs v0.0.0-20181101203652-af5082808c83
 	github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601
 	github.com/containerd/console => github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
-	github.com/containerd/containerd => github.com/rancher/containerd v1.3.0-k3s.4
+	github.com/containerd/containerd => github.com/rancher/containerd v1.3.0-k3s.5
 	github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02
 	github.com/containerd/cri => github.com/rancher/cri v1.3.0-k3s.2
 	github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rakelkar/gonetsh v0.0.0-20190719023240-501daadcadf8 h1:83l9gPhYtgxODlZKU0Odq4pQuDcMZEVgAh364+PV3OU=
 github.com/rakelkar/gonetsh v0.0.0-20190719023240-501daadcadf8/go.mod h1:4XHkfaUj+URzGO9sohoAgt2V9Y8nIW7fugpu0E6gShk=
-github.com/rancher/containerd v1.3.0-k3s.4 h1:Vq9EJQEm01eeWaBtgU35KxWeuVU5LwW43EmDIEnqpDQ=
-github.com/rancher/containerd v1.3.0-k3s.4/go.mod h1:ZMfzmqce2Z+QSEqdHMfeJs1TZ/UeJ1aDrazjpQT4ehM=
+github.com/rancher/containerd v1.3.0-k3s.5 h1:r5GheXz59KQpEdYPxRd53vfFhipnQG/g3MI5NkNPDQI=
+github.com/rancher/containerd v1.3.0-k3s.5/go.mod h1:ZMfzmqce2Z+QSEqdHMfeJs1TZ/UeJ1aDrazjpQT4ehM=
 github.com/rancher/cri v1.3.0-k3s.2 h1:k2XFyD+ZdsGvNfugdvqD38KSMANT3JmTFULFM2CtI70=
 github.com/rancher/cri v1.3.0-k3s.2/go.mod h1:Ht5T1dIKzm+4NExmb7wDVG6qR+j0xeXIjjhCv1d9geY=
 github.com/rancher/cri-tools v1.16.1-k3s.1 h1:iporgQ46noE6dtLzq6fWcIO2qjyPZy2m42d2P+UnGJg=

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -54,7 +54,7 @@ const ContainerdConfigTemplate = `
   {{ if $v.Auth.Username }}username = "{{ $v.Auth.Username }}"{{end}}
   {{ if $v.Auth.Password }}password = "{{ $v.Auth.Password }}"{{end}}
   {{ if $v.Auth.Auth }}auth = "{{ $v.Auth.Auth }}"{{end}}
-  {{ if $v.Auth.IdentityToken }}identity_token = "{{ $v.Auth.IdentityToken }}"{{end}}
+  {{ if $v.Auth.IdentityToken }}identitytoken = "{{ $v.Auth.IdentityToken }}"{{end}}
 {{end}}
 {{ if $v.TLS }}
 [plugins.cri.registry.configs."{{$k}}".tls]

--- a/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
@@ -196,10 +196,11 @@ func (a *dockerAuthorizer) generateTokenOptions(ctx context.Context, host string
 	}
 
 	scope, ok := c.parameters["scope"]
-	if !ok {
-		return tokenOptions{}, errors.Errorf("no scope specified for token auth challenge")
+	if ok {
+		to.scopes = append(to.scopes, scope)
+	} else {
+		log.G(ctx).WithField("host", host).Debug("no scope specified for token auth challenge")
 	}
-	to.scopes = append(to.scopes, scope)
 
 	if a.credentials != nil {
 		to.username, to.secret, err = a.credentials(host)
@@ -273,9 +274,6 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (string, error) {
 	to := ah.common
 
 	to.scopes = getTokenScopes(ctx, to.scopes)
-	if len(to.scopes) == 0 {
-		return "", errors.Errorf("no scope specified for token auth challenge")
-	}
 
 	// Docs: https://docs.docker.com/registry/spec/auth/scope
 	scoped := strings.Join(to.scopes, " ")
@@ -332,7 +330,9 @@ type postTokenResponse struct {
 
 func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions) (string, error) {
 	form := url.Values{}
-	form.Set("scope", strings.Join(to.scopes, " "))
+	if len(to.scopes) > 0 {
+		form.Set("scope", strings.Join(to.scopes, " "))
+	}
 	form.Set("service", to.service)
 	// TODO: Allow setting client_id
 	form.Set("client_id", "containerd-client")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/container-storage-interface/spec/lib/go/csi
 github.com/containerd/cgroups
 # github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1 => github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
 github.com/containerd/console
-# github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69 => github.com/rancher/containerd v1.3.0-k3s.4
+# github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69 => github.com/rancher/containerd v1.3.0-k3s.5
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/containers/v1


### PR DESCRIPTION
Resolves an error message when using containerd with JCR "no scope specified for token auth challenge"