### PR TITLE
Revert "Merge pull request #1190 from erikwilson/wireguard-keepalive"

### DIFF
--- a/pkg/agent/flannel/setup.go
+++ b/pkg/agent/flannel/setup.go
@@ -58,7 +58,7 @@ const (
 	wireguardBackend = `{
 	"Type": "extension",
 	"PreStartupCommand": "wg genkey | tee privatekey | wg pubkey",
-	"PostStartupCommand": "export SUBNET_IP=$(echo $SUBNET | cut -d'/' -f 1); ip link del flannel.1 2>/dev/null; echo $PATH >&2; wg-add.sh flannel.1 && wg set flannel.1 listen-port 51820 private-key privatekey persistent-keepalive 25 && ip addr add $SUBNET_IP/32 dev flannel.1 && ip link set flannel.1 up && ip route add $NETWORK dev flannel.1",
+	"PostStartupCommand": "export SUBNET_IP=$(echo $SUBNET | cut -d'/' -f 1); ip link del flannel.1 2>/dev/null; echo $PATH >&2; wg-add.sh flannel.1 && wg set flannel.1 listen-port 51820 private-key privatekey && ip addr add $SUBNET_IP/32 dev flannel.1 && ip link set flannel.1 up && ip route add $NETWORK dev flannel.1",
 	"ShutdownCommand": "ip link del flannel.1",
 	"SubnetAddCommand": "read PUBLICKEY; wg set flannel.1 peer $PUBLICKEY endpoint $PUBLIC_IP:51820 allowed-ips $SUBNET",
 	"SubnetRemoveCommand": "read PUBLICKEY; wg set flannel.1 peer $PUBLICKEY remove"


### PR DESCRIPTION
This reverts commit e712cdf7e8fcc00dfb9786e745efcafb5366ca45, reversing
changes made to d5929bc8c873a33ecf0c187699dbe6de1d6f2f97.

Wireguard docs fail to describe that persistent-keepalive is only valid
when peer is set.