### PR TITLE
Add check if swap is enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -271,6 +271,12 @@ verify_downloader() {
     return 0
 }
 
+# --- Verify swap is not enabled ---
+verify_no_swap() {
+    [ "$(wc -l < /proc/swaps)" == "1"  ] && return
+    fatal "Swap is enabled"
+}
+
 # --- verify existence of semanage when SELinux is enabled ---
 verify_semanage() {
     if [ -x "$(which getenforce)" ]; then
@@ -724,6 +730,7 @@ eval set -- $(escape "${INSTALL_K3S_EXEC}") $(quote "$@")
 # --- run the install process --
 {
     verify_system
+    verify_no_swap
     setup_env "$@"
     download_and_verify
     create_symlinks


### PR DESCRIPTION
A simple function that checks if swap is enabled on a system, for issue #866 
Uses /proc/swaps for a check that should work on most distros.

I want to add that this check can be passed by running swapoff but after a reboot swap will be enabled again. Does this need additional checks?

p.s. Funny I actually have swap enabled on my k3s setup..... time to fix that! 