### PR TITLE
Run kubelet with containerd flag

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -93,6 +93,7 @@ func startKubelet(cfg *config.Agent) {
 	if cfg.RuntimeSocket != "" {
 		argsMap["container-runtime"] = "remote"
 		argsMap["container-runtime-endpoint"] = cfg.RuntimeSocket
+		argsMap["containerd"] = cfg.RuntimeSocket
 		argsMap["serialize-image-pulls"] = "false"
 	} else if cfg.PauseImage != "" {
 		argsMap["pod-infra-container-image"] = cfg.PauseImage


### PR DESCRIPTION
The containerd flag was accidentally added to kubelet and is
deprecated, but needed for cadvisor to properly connect with
the k3s containerd socket, so adding for now.

For #473