### PR TITLE
Start cgroups service in OpenRC script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -646,6 +646,7 @@ create_openrc_service_file() {
 
 depend() {
     after network-online
+    want cgroups
 }
 
 start_pre() {


### PR DESCRIPTION
cgroups init script is present in Alpine Linux since 3.8.

Fixes #660