### PR TITLE
Add github action ci workflow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -251,6 +251,39 @@ volumes:
 
 ---
 kind: pipeline
+name: dispatch
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: dispatch
+    image: rancher/dapper:v0.4.2
+    environment:
+      PAT_USERNAME:
+        from_secret: pat_username
+      PAT_TOKEN:
+        from_secret: pat_token
+    commands:
+      - dapper dispatch
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/head/master
+        - refs/tags/*
+      event:
+        - tag
+volumes:
+- name: docker
+  host:
+   path: /var/run/docker.sock
+---
+kind: pipeline
 name: manifest
 
 platform:

--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+set -x
+
+REPO="https://api.github.com/repos/rancher/k3s-upgrade/dispatches"
+
+# send dispatch event to REPO
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.everest-preview+json"  \
+        -H "Content-Type: application/json" $REPO\
+        --data '{"event_type": "create_tag", "client_payload": {"tag":"'"$DRONE_TAG"'"}}'


### PR DESCRIPTION
The PR should sends a dispatch event to the k3s-upgrade repo which will in turn listen to it and create a new tag cutting a new image for k3s-upgrade with the same tag name, this PR depends on two github action secrets:

- PAT_USERNAME
- PAT_TOKEN