### PR TITLE
contrib/ansible: Fix home path and use kubectl to set the server url in conf

### DIFF
--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -58,10 +58,9 @@
     owner: "{{ ansible_user }}"
 
 - name: Replace https://localhost:6443 by https://master-pi:6443
-  replace:
-    path: ~{{ ansible_user }}/.kube/config
-    regexp: 'https://localhost:6443'
-    replace: 'https://{{master_ip}}:6443'
+  command: k3s kubectl config set-cluster default
+    --server=https://{{ master_ip }}:6443
+    --kubeconfig ~{{ ansible_user }}/.kube/config
 
 - name: Create kubectl symlink
   file:

--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -46,20 +46,20 @@
 
 - name: Create directory .kube
   file:
-    path: /home/{{ ansible_user }}/.kube
+    path: ~{{ ansible_user }}/.kube
     state: directory
     owner: "{{ ansible_user }}"
 
 - name: Copy config file to user home directory
   copy:
     src: /etc/rancher/k3s/k3s.yaml
-    dest: /home/{{ ansible_user }}/.kube/config
+    dest: ~{{ ansible_user }}/.kube/config
     remote_src: yes
     owner: "{{ ansible_user }}"
 
 - name: Replace https://localhost:6443 by https://master-pi:6443
   replace:
-    path: /home/{{ ansible_user }}/.kube/config
+    path: ~{{ ansible_user }}/.kube/config
     regexp: 'https://localhost:6443'
     replace: 'https://{{master_ip}}:6443'
 


### PR DESCRIPTION
Sometimes https://127.0.0.1:6443 can be written in the conf by default instead of https://localhost:6443, using `kubectl config set-cluster default` solves the issue.

Home directory is not always in `/home` using `~user` expands the correct path.