### PR TITLE
do not rename inuse files

### DIFF
--- a/pkg/passwd/passwd.go
+++ b/pkg/passwd/passwd.go
@@ -133,17 +133,21 @@ func (p *Passwd) Write(passwdFile string) error {
 }
 
 func writePasswords(passwdFile string, records [][]string) error {
-	out, err := os.Create(passwdFile + ".tmp")
+	err := func() error {
+		// ensure to close tmp file before rename for filesystems like NTFS
+		out, err := os.Create(passwdFile + ".tmp")
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		if err := out.Chmod(0600); err != nil {
+			return err
+		}
+
+		return csv.NewWriter(out).WriteAll(records)
+	}()
 	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if err := out.Chmod(0600); err != nil {
-		return err
-	}
-
-	if err := csv.NewWriter(out).WriteAll(records); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Renaming files that are open does not work on windows depending on how file is opened. 

Add a scope to ensure that the defer close occurs before rename.