### PR TITLE
package-cli: Remove redundant rm -rf build/data

### DIFF
--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -7,11 +7,10 @@ cd $(dirname $0)/..
 
 GO=${GO-go}
 
-rm -rf bin/crictl bin/kubectl bin/k3s-agent bin/k3s-server bin/kubectl bin/k3s build/data
-ln -s containerd bin/k3s-agent
-ln -s containerd bin/k3s-server
-ln -s containerd bin/kubectl
-ln -s containerd bin/crictl
+for i in crictl kubectl k3s-agent k3s-server k3s; do
+    ln -fs containerd bin/$i
+done
+
 for i in bridge flannel host-local loopback portmap; do
     if [ -e ./bin/$i ]; then
         rm -f ./bin/$i
@@ -58,8 +57,8 @@ LDFLAGS="
     -w -s
 "
 STATIC="-extldflags '-static'"
-if [ "$DQLITE" = "true" ]; then
-    DQLITE_TAGS="dqlite"
+if [ "$DQLITE" = 'true' ]; then
+    DQLITE_TAGS='dqlite'
 fi
 CGO_ENABLED=0 "${GO}" build -tags "$DQLITE_TAGS" -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
 

--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -8,7 +8,8 @@ cd $(dirname $0)/..
 GO=${GO-go}
 
 for i in crictl kubectl k3s-agent k3s-server k3s; do
-    ln -fs containerd bin/$i
+    rm -f bin/$i
+    ln -s containerd bin/$i
 done
 
 for i in bridge flannel host-local loopback portmap; do


### PR DESCRIPTION
Moving symlinks to containerd to a for loop makes maintenance easier.
It also reveals a duplicate, redundant, rm -rf build/data and one
duplicate, redundant, rm -rf bin/kubectl, that can be both be purged.
