### PR TITLE
Ask more clearly for K3s args and logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,10 @@ assignees: ''
 <!-- Thanks for helping us to improve k3s! We welcome all bug reports. Please fill out each area of the template so we can better help you.  ***You can delete this message portion of the bug report.*** -->
 
 **Version:**
-<!-- Provide the output from `k3s -v` and provide the flags used to install or run k3s server. -->
+<!-- Provide the output from `k3s -v` -->
+
+**K3s arguments:**
+<!-- Provide the flags used to install or run k3s server. -->
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
@@ -24,5 +27,5 @@ assignees: ''
 **Actual behavior**
 <!-- A clear and concise description of what actually happened. -->
 
-**Additional context**
-<!-- Add any other context about the problem here. -->
+**Additional context / logs**
+<!-- Add any other context and/or logs about the problem here. -->


### PR DESCRIPTION
In the bug report template, more clearly ask the user for K3s arguments and logs