### PR TITLE
install.sh: cleanup /run on uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -594,6 +594,8 @@ rm -rf /var/lib/rancher/k3s
 rm -rf /var/lib/kubelet
 rm -f ${BIN_DIR}/k3s
 rm -f ${KILLALL_K3S_SH}
+rm -f /run/k3s
+rm -f /run/flannel
 EOF
     $SUDO chmod 755 ${UNINSTALL_K3S_SH}
     $SUDO chown root:root ${UNINSTALL_K3S_SH}


### PR DESCRIPTION
Fix for issue 1326, added lines to delete /run/k3s and /run/flannel in create_uninstall() function.