### PR TITLE
enable agent to start on windows

### DIFF
--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/rancher/k3s/pkg/agent"
 	"github.com/rancher/k3s/pkg/cli/cmds"
@@ -19,7 +20,7 @@ func Run(ctx *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	if os.Getuid() != 0 {
+	if os.Getuid() != 0 && runtime.GOOS != "windows" {
 		return fmt.Errorf("agent must be ran as root")
 	}
 


### PR DESCRIPTION
This enables agent to start on windows.

I tested connecting to a server running on another windows node, things seemingly worked. Currently I am hand configuring flannel and passing in a few flags to enable startup.