### PR TITLE
package-cli: Remove superfluous file exist check

### DIFF
--- a/scripts/package-cli
+++ b/scripts/package-cli
@@ -13,10 +13,8 @@ ln -s containerd bin/k3s-server
 ln -s containerd bin/kubectl
 ln -s containerd bin/crictl
 for i in bridge flannel host-local loopback portmap; do
-    if [ -e ./bin/$i ]; then
-        rm -f ./bin/$i
-    fi
-    ln -s cni ./bin/$i
+    rm -f bin/$i
+    ln -s cni bin/$i
 done
 
 cp contrib/util/check-config.sh bin/check-config


### PR DESCRIPTION
The command rm -f will succeed even if run for a file that does not
exist. Hence it is superfluous to existence check a file that we want
to purge with rm -f, which makes the script a bit simpler to read.
