### PR TITLE
[systemd] really wait for network to come online

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -644,6 +644,7 @@ create_systemd_service_file() {
 [Unit]
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
+After=network-online.target
 Wants=network-online.target
 
 [Install]

--- a/k3s.service
+++ b/k3s.service
@@ -2,6 +2,7 @@
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=notify

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -659,6 +659,7 @@ create_systemd_service_file() {
 [Unit]
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
+After=network-online.target
 Wants=network-online.target
 Conflicts=${conflicts}
 


### PR DESCRIPTION
`Wants=` is required to actually set the dependency on `network-online.service`
`After=` is required or `k3s.service` will be started at the same time as `network-online.service`

In network environments with slow DHCP, both are required to ensure valid network configuration for k3s

**Before:**
```
-- Logs begin at Tue 2020-04-22 01:02:36 CEST, end at Wed 2020-04-22 01:04:01 CEST. --
Apr 22 01:03:48 localhost systemd[1]: Starting Lightweight Kubernetes...
Apr 22 01:03:48 localhost k3s[860]: time="2020-04-22T01:03:48Z" level=info msg="Preparing data dir /var/lib/rancher/k3s/data/44b43856accd3b248b71bf2f479f3513c942559af34c7b91b2ed3795f107c815"
Apr 22 01:03:50 localhost k3s[860]: time="2020-04-22T01:03:50.989048441Z" level=info msg="Starting k3s v1.18.2-rc1+k3s1 (553517e1)"
Apr 22 01:03:50 localhost k3s[860]: time="2020-04-22T01:03:50.996872957Z" level=info msg="Kine listening on unix://kine.sock"
Apr 22 01:03:51 localhost k3s[860]: time="2020-04-22T01:03:51.290390547Z" level=info msg="Active TLS secret  (ver=) (count 6): map[listener.cattle.io/cn-10.81.0.1:10.81.0.1 listener.cattle.io/cn-127.0.0.1:127.0.0.1 listener.cattle.io/cn-kubernetes:kubernetes liste>
Apr 22 01:03:51 localhost k3s[860]: time="2020-04-22T01:03:51.299223901Z" level=info msg="Running kube-apiserver --advertise-port=6443 --allow-privileged=true --anonymous-auth=false --api-audiences=unknown --authorization-mode=Node,RBAC --basic-auth-file=/var/lib/>
Apr 22 01:03:51 localhost k3s[860]: Flag --basic-auth-file has been deprecated, Basic authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments.
Apr 22 01:03:51 localhost k3s[860]: Error: Unable to find suitable network address.error='no default routes found in "/proc/net/route" or "/proc/net/ipv6_route"'. Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this.
Apr 22 01:03:51 localhost k3s[860]: Usage:
Apr 22 01:03:51 localhost k3s[860]:   kube-apiserver [flags]
Apr 22 01:03:51 localhost k3s[860]: Generic flags:
...
Apr 22 01:03:51 localhost k3s[860]: time="2020-04-22T01:03:51.304746618Z" level=fatal msg="apiserver exited: Unable to find suitable network address.error='no default routes found in \"/proc/net/route\" or \"/proc/net/ipv6_route\"'. Try to set the AdvertiseAddress>
Apr 22 01:03:51 localhost systemd[1]: k3s.service: Main process exited, code=exited, status=1/FAILURE
Apr 22 01:03:51 localhost systemd[1]: k3s.service: Failed with result 'exit-code'.
Apr 22 01:03:51 localhost systemd[1]: Failed to start Lightweight Kubernetes.
```

**After:**
```
-- Logs begin at Wed 2020-04-22 01:49:11 CEST, end at Wed 2020-04-22 01:51:28 CEST. --
Apr 22 01:49:57 k3s-server-0 systemd[1]: Starting Lightweight Kubernetes...
Apr 22 01:49:57 k3s-server-0 k3s[1708]: time="2020-04-22T01:49:57+02:00" level=info msg="Preparing data dir /var/lib/rancher/k3s/data/44b43856accd3b248b71bf2f479f3513c942559af34c7b91b2ed3795f107c815"
Apr 22 01:49:59 k3s-server-0 k3s[1708]: time="2020-04-22T01:49:59.198692537+02:00" level=info msg="Starting k3s v1.18.2-rc1+k3s1 (553517e1)"
Apr 22 01:49:59 k3s-server-0 k3s[1708]: time="2020-04-22T01:49:59.208804582+02:00" level=info msg="Kine listening on unix://kine.sock"
Apr 22 01:49:59 k3s-server-0 k3s[1708]: time="2020-04-22T01:49:59.645294652+02:00" level=info msg="Active TLS secret  (ver=) (count 7): map[listener.cattle.io/cn-10.81.0.1:10.81.0.1 listener.cattle.io/cn-127.0.0.1:127.0.0.1 listener.cattle.io/cn-192.168.1.100:19>
Apr 22 01:49:59 k3s-server-0 k3s[1708]: time="2020-04-22T01:49:59.655372782+02:00" level=info msg="Running kube-apiserver --advertise-port=6443 --allow-privileged=true --anonymous-auth=false --api-audiences=unknown --authorization-mode=Node,RBAC --basic-auth-file=>
Apr 22 01:49:59 k3s-server-0 k3s[1708]: Flag --basic-auth-file has been deprecated, Basic authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments.
Apr 22 01:49:59 k3s-server-0 k3s[1708]: I0422 01:49:59.655974    1708 server.go:682] external host was not specified, using 192.168.1.100
Apr 22 01:49:59 k3s-server-0 k3s[1708]: I0422 01:49:59.656289    1708 server.go:166] Version: v1.18.2-rc1+k3s1
...
```