### PR TITLE
Only need to resolve the path of host-local if Flannel is enabled

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -305,11 +305,6 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 		return nil, err
 	}
 
-	hostLocal, err := exec.LookPath("host-local")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find host-local")
-	}
-
 	var flannelIface *sysnet.Interface
 	if !envInfo.NoFlannel && len(envInfo.FlannelIface) > 0 {
 		flannelIface, err = sysnet.InterfaceByName(envInfo.FlannelIface)
@@ -443,6 +438,11 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 	}
 
 	if !nodeConfig.NoFlannel {
+		hostLocal, err := exec.LookPath("host-local")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to find host-local")
+		}
+
 		if envInfo.FlannelConf == "" {
 			nodeConfig.FlannelConf = filepath.Join(envInfo.DataDir, "etc/flannel/net-conf.json")
 		} else {


### PR DESCRIPTION
Right now we require host-local binary to exist always.  This is always there because we include it, but we are working towards variants of k3s that don't include CNI or many other components. This change will require host-local only if k3s' embedded flannel is enabled.