### PR TITLE
Suppport static pods at ${datadir}/agent/staticpods

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 )
 
+const (
+	DefaultPodManifestPath = "pod-manifests"
+)
+
 func Get(ctx context.Context, agent cmds.Agent) *config.Node {
 	for {
 		agentConfig, err := get(&agent)
@@ -475,6 +479,7 @@ func get(envInfo *cmds.Agent) (*config.Node, error) {
 	nodeConfig.AgentConfig.DisableCCM = controlConfig.DisableCCM
 	nodeConfig.AgentConfig.DisableNPC = controlConfig.DisableNPC
 	nodeConfig.AgentConfig.Rootless = envInfo.Rootless
+	nodeConfig.AgentConfig.PodManifests = filepath.Join(envInfo.DataDir, DefaultPodManifestPath)
 	nodeConfig.DisableSELinux = envInfo.DisableSELinux
 
 	return nodeConfig, nil

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -70,6 +70,12 @@ func startKubelet(cfg *config.Agent) {
 		"anonymous-auth":               "false",
 		"authorization-mode":           modes.ModeWebhook,
 	}
+	if cfg.PodManifests != "" && argsMap["pod-manifest-path"] == "" {
+		argsMap["pod-manifest-path"] = cfg.PodManifests
+	}
+	if err := os.MkdirAll(argsMap["pod-manifest-path"], 0755); err != nil {
+		logrus.Errorf("Failed to mkdir %s: %v", argsMap["pod-manifest-path"], err)
+	}
 	if cfg.RootDir != "" {
 		argsMap["root-dir"] = cfg.RootDir
 		argsMap["cert-dir"] = filepath.Join(cfg.RootDir, "pki")

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -49,6 +49,7 @@ type Containerd struct {
 }
 
 type Agent struct {
+	PodManifests            string
 	NodeName                string
 	NodeConfigPath          string
 	ServingKubeletCert      string


### PR DESCRIPTION
By default now the kubelet will look for ${datadir}/agent/staticpods
to autodeploy as pods. This is for static pods and is different
from the ${datadir}/server/manifests folder which will deploy
any k8s type.