### PR TITLE
Encapsulate execution logic

### DIFF
--- a/pkg/daemons/executor/embed.go
+++ b/pkg/daemons/executor/embed.go
@@ -1,0 +1,80 @@
+// +build !no_embedded_executor
+
+package executor
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+
+	proxy "k8s.io/kubernetes/cmd/kube-proxy/app"
+	kubelet "k8s.io/kubernetes/cmd/kubelet/app"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app"
+	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app"
+	sapp "k8s.io/kubernetes/cmd/kube-scheduler/app"
+)
+
+func init() {
+	executor = Embedded{}
+}
+
+type Embedded struct{}
+
+func (Embedded) Kubelet(args []string) error {
+	command := kubelet.NewKubeletCommand(context.Background().Done())
+	command.SetArgs(args)
+
+	go func() {
+		logrus.Fatalf("kubelet exited: %v", command.Execute())
+	}()
+
+	return nil
+}
+
+func (Embedded) KubeProxy(args []string) error {
+	command := proxy.NewProxyCommand()
+	command.SetArgs(args)
+
+	go func() {
+		logrus.Fatalf("kube-proxy exited: %v", command.Execute())
+	}()
+
+	return nil
+}
+
+func (Embedded) APIServer(ctx context.Context, args []string) (authenticator.Request, http.Handler, error) {
+	command := app.NewAPIServerCommand(ctx.Done())
+	command.SetArgs(args)
+
+	go func() {
+		logrus.Fatalf("apiserver exited: %v", command.Execute())
+	}()
+
+	startupConfig := <-app.StartupConfig
+	return startupConfig.Authenticator, startupConfig.Handler, nil
+}
+
+func (Embedded) Scheduler(args []string) error {
+	command := sapp.NewSchedulerCommand()
+	command.SetArgs(args)
+
+	go func() {
+		logrus.Fatalf("scheduler exited: %v", command.Execute())
+	}()
+
+	return nil
+}
+
+func (Embedded) ControllerManager(args []string) error {
+	command := cmapp.NewControllerManagerCommand()
+	command.SetArgs(args)
+
+	go func() {
+		logrus.Fatalf("controller-manager exited: %v", command.Execute())
+	}()
+
+	return nil
+}

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -1,0 +1,44 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+type Executor interface {
+	Kubelet(args []string) error
+	KubeProxy(args []string) error
+	APIServer(ctx context.Context, args []string) (authenticator.Request, http.Handler, error)
+	Scheduler(args []string) error
+	ControllerManager(args []string) error
+}
+
+var (
+	executor Executor
+)
+
+func Set(driver Executor) {
+	executor = driver
+}
+
+func Kubelet(args []string) error {
+	return executor.Kubelet(args)
+}
+
+func KubeProxy(args []string) error {
+	return executor.KubeProxy(args)
+}
+
+func APIServer(ctx context.Context, args []string) (authenticator.Request, http.Handler, error) {
+	return executor.APIServer(ctx, args)
+}
+
+func Scheduler(args []string) error {
+	return executor.Scheduler(args)
+}
+
+func ControllerManager(args []string) error {
+	return executor.ControllerManager(args)
+}


### PR DESCRIPTION
This moves all the calls to cobra root commands to one package
so that we can change the behavior of running components as embedded
or external.