### PR TITLE
contrib/ansible: Fix systemd TimeoutStartSec in contrib/ansible

### DIFF
--- a/contrib/ansible/roles/k3s/master/templates/k3s.service.j2
+++ b/contrib/ansible/roles/k3s/master/templates/k3s.service.j2
@@ -14,7 +14,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
-TimeoutStartSec=infinity
+TimeoutStartSec=0
 Restart=always
 RestartSec=5s
 

--- a/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
+++ b/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
@@ -14,7 +14,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
-TimeoutStartSec=infinity
+TimeoutStartSec=0
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
This fixes the issue #360 that was fixed in #365 but not inside the ansible playbook.

Signed-off-by: Julien DOCHE <julien.doche@gmail.com>