### PR TITLE
Remove duplicate Ansible task for RHEL nodes

### DIFF
--- a/contrib/ansible/roles/prereq/tasks/main.yml
+++ b/contrib/ansible/roles/prereq/tasks/main.yml
@@ -18,14 +18,6 @@
     state: present
     reload: yes
 
-- name: Set bridge-nf-call-iptables (just to be sure)
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: "1"
-    state: present
-    reload: yes
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
 - name: Set bridge-nf-call-ip6tables (just to be sure)
   sysctl:
     name: net.bridge.bridge-nf-call-iptables


### PR DESCRIPTION
I was evaluating the `k3s` install playbook and noticed it had a duplicate task in the `prereq` role, so this PR removes that duplicate task.