### PR TITLE
ansible: Ensure both iptables and ip6tables are set to 1 on RHEL in prereqs.

### DIFF
--- a/contrib/ansible/roles/prereq/tasks/main.yml
+++ b/contrib/ansible/roles/prereq/tasks/main.yml
@@ -20,16 +20,11 @@
 
 - name: Set bridge-nf-call-iptables (just to be sure)
   sysctl:
-    name: net.bridge.bridge-nf-call-iptables
+    name: "{{ items }}"
     value: "1"
     state: present
     reload: yes
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- name: Set bridge-nf-call-ip6tables (just to be sure)
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: "1"
-    state: present
-    reload: yes
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  loop:
+    - net.bridge.bridge-nf-call-iptables
+    - net.bridge.bridge-nf-call-ip6tables


### PR DESCRIPTION
I noticed when evaluating the Ansible playbook that two tasks in the prereq role did the exact same thing (not following the documentation in the 'name' of the task).

I fixed that problem by using one task and a loop, setting both iptables and ip6tables explicitly in the one task.﻿
