### PR TITLE
Issue #1724: Fix ansible-lint and yamllint code style issues

### DIFF
--- a/contrib/ansible/.yamllint
+++ b/contrib/ansible/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no']

--- a/contrib/ansible/inventory/group_vars/all.yml
+++ b/contrib/ansible/inventory/group_vars/all.yml
@@ -1,3 +1,4 @@
+---
 k3s_version: v0.8.1
 ansible_user: debian
 systemd_dir: /etc/systemd/system

--- a/contrib/ansible/reset.yml
+++ b/contrib/ansible/reset.yml
@@ -4,4 +4,4 @@
   gather_facts: yes
   become: yes
   roles:
-    - { role: reset }
+    - role: reset

--- a/contrib/ansible/roles/download/tasks/main.yml
+++ b/contrib/ansible/roles/download/tasks/main.yml
@@ -12,7 +12,8 @@
     owner: root
     group: root
     mode: 755
-  when: ( ansible_facts.architecture == "x86_64" )
+  when:
+    - ansible_facts.architecture == "x86_64"
 
 - name: Download k3s binary arm64
   get_url:
@@ -21,9 +22,9 @@
     owner: root
     group: root
     mode: 755
-  when: ( ansible_facts.architecture is search("arm") )
-          and
-        ( ansible_facts.userspace_bits == "64" )
+  when:
+    - ansible_facts.architecture is search("arm")
+    - ansible_facts.userspace_bits == "64"
 
 - name: Download k3s binary armhf
   get_url:
@@ -32,6 +33,6 @@
     owner: root
     group: root
     mode: 755
-  when: ( ansible_facts.architecture is search("arm") )
-          and
-        ( ansible_facts.userspace_bits == "32" )
+  when:
+    - ansible_facts.architecture is search("arm")
+    - ansible_facts.userspace_bits == "32"

--- a/contrib/ansible/roles/download/tasks/main.yml
+++ b/contrib/ansible/roles/download/tasks/main.yml
@@ -7,32 +7,31 @@
 
 - name: Download k3s binary x64
   get_url:
-      url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s
-      dest: /usr/local/bin/k3s
-      owner: root
-      group: root
-      mode: 755
-#  when: ( ansible_facts.userspace_architecture == "x86_64" )
+    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s
+    dest: /usr/local/bin/k3s
+    owner: root
+    group: root
+    mode: 755
   when: ( ansible_facts.architecture == "x86_64" )
 
 - name: Download k3s binary arm64
   get_url:
-      url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-arm64
-      dest: /usr/local/bin/k3s
-      owner: root
-      group: root
-      mode: 755
+    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-arm64
+    dest: /usr/local/bin/k3s
+    owner: root
+    group: root
+    mode: 755
   when: ( ansible_facts.architecture is search("arm") )
           and
         ( ansible_facts.userspace_bits == "64" )
 
 - name: Download k3s binary armhf
   get_url:
-      url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-armhf
-      dest: /usr/local/bin/k3s
-      owner: root
-      group: root
-      mode: 755
+    url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-armhf
+    dest: /usr/local/bin/k3s
+    owner: root
+    group: root
+    mode: 755
   when: ( ansible_facts.architecture is search("arm") )
           and
         ( ansible_facts.userspace_bits == "32" )

--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -58,9 +58,10 @@
     owner: "{{ ansible_user }}"
 
 - name: Replace https://localhost:6443 by https://master-pi:6443
-  command: k3s kubectl config set-cluster default
-    --server=https://{{ master_ip }}:6443
-    --kubeconfig ~{{ ansible_user }}/.kube/config
+  command: >-
+    k3s kubectl config set-cluster default
+      --server=https://{{ master_ip }}:6443
+      --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
 - name: Create kubectl symlink

--- a/contrib/ansible/roles/k3s/master/tasks/main.yml
+++ b/contrib/ansible/roles/k3s/master/tasks/main.yml
@@ -36,10 +36,10 @@
   register: node_token
 
 - name: Store Master node-token
-  set_fact: 
-   token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
+  set_fact:
+    token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
 
-- name: Restore node-token file access 
+- name: Restore node-token file access
   file:
     path: /var/lib/rancher/k3s/server
     mode: "{{ p.stat.mode }}"
@@ -61,6 +61,7 @@
   command: k3s kubectl config set-cluster default
     --server=https://{{ master_ip }}:6443
     --kubeconfig ~{{ ansible_user }}/.kube/config
+  changed_when: true
 
 - name: Create kubectl symlink
   file:

--- a/contrib/ansible/roles/prereq/tasks/main.yml
+++ b/contrib/ansible/roles/prereq/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set SELinux to disabled state
   selinux:
     state: disabled
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Enable IPv4 forwarding
   sysctl:
@@ -24,7 +24,7 @@
     value: "1"
     state: present
     reload: yes
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Set bridge-nf-call-ip6tables (just to be sure)
   sysctl:
@@ -32,4 +32,4 @@
     value: "1"
     state: present
     reload: yes
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']

--- a/contrib/ansible/roles/raspbian/tasks/main.yml
+++ b/contrib/ansible/roles/raspbian/tasks/main.yml
@@ -11,14 +11,14 @@
     regexp: '^(.*rootwait)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  when: ( cmdline.stat.path is defined )
-          and
-        ( ansible_facts.architecture is search("arm") )
+  when:
+    - cmdline.stat.path is defined
+    - ansible_facts.architecture is search("arm")
   register: boot_cmdline
 
 - name: Rebooting on Raspbian
   command: reboot now
   ignore_errors: true
-  when: ( boot_cmdline | changed )
-          and
-        ( ansible_facts.architecture is search("arm") )
+  when:
+    - boot_cmdline | changed
+    - ansible_facts.architecture is search("arm")

--- a/contrib/ansible/roles/raspbian/tasks/main.yml
+++ b/contrib/ansible/roles/raspbian/tasks/main.yml
@@ -16,8 +16,8 @@
         ( ansible_facts.architecture is search("arm") )
   register: boot_cmdline
 
-- name: Rebooting on Raspbian 
-  shell: reboot now
+- name: Rebooting on Raspbian
+  command: reboot now
   ignore_errors: true
   when: ( boot_cmdline | changed )
           and

--- a/contrib/ansible/site.yml
+++ b/contrib/ansible/site.yml
@@ -4,19 +4,19 @@
   gather_facts: yes
   become: yes
   roles:
-    - { role: prereq }
-    - { role: download }
-    - { role: raspbian }
+    - role: prereq
+    - role: download
+    - role: raspbian
 
 
 - hosts: master
-#  gather_facts: yes
+  # gather_facts: yes
   become: yes
   roles:
-    - { role: k3s/master }
+    - role: k3s/master
 
 - hosts: node
-#  gather_facts: yes
+  # gather_facts: yes
   become: yes
   roles:
-    - { role: k3s/node }
+    - role: k3s/node

--- a/contrib/ansible/site.yml
+++ b/contrib/ansible/site.yml
@@ -10,13 +10,11 @@
 
 
 - hosts: master
-  # gather_facts: yes
   become: yes
   roles:
     - role: k3s/master
 
 - hosts: node
-  # gather_facts: yes
   become: yes
   roles:
     - role: k3s/node


### PR DESCRIPTION
Closes #1724.

This PR adds a `.yamllint` configuration suitable for Ansible playbooks, fixes a few issues identified in #1724 by `ansible-lint` and `.yamllint`, and also fixes code style a few other places to make the Ansible playbook slightly more readable.