### PR TITLE
Fixes #1727: Fix Ansible inventory group name with dash in it.

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -32,7 +32,7 @@ Add the system information gathered above into a file called hosts.ini. For exam
 [node]
 192.16.35.[10:11]
 
-[k3s-cluster:children]
+[k3s_cluster:children]
 master
 node
 

--- a/contrib/ansible/inventory/hosts.ini
+++ b/contrib/ansible/inventory/hosts.ini
@@ -7,6 +7,6 @@
 192.168.1.16
 192.168.1.32
 
-[k3s-cluster:children]
+[k3s_cluster:children]
 master
 node

--- a/contrib/ansible/reset.yml
+++ b/contrib/ansible/reset.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: k3s-cluster
+- hosts: k3s_cluster
   gather_facts: yes
   become: yes
   roles:

--- a/contrib/ansible/site.yml
+++ b/contrib/ansible/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: k3s-cluster
+- hosts: k3s_cluster
   gather_facts: yes
   become: yes
   roles:


### PR DESCRIPTION
Closes #1727.

This PR changes the k3s-cluster group name to k3s_cluster, since the former is an invalid group name using Ansible's defaults in 2.9.6 and later. See #1727 for details.﻿
