### PR TITLE
Fixes #1729: Use 'is changed' instead of non-existent changed filter.

### DIFF
--- a/contrib/ansible/roles/raspbian/tasks/main.yml
+++ b/contrib/ansible/roles/raspbian/tasks/main.yml
@@ -19,6 +19,6 @@
 - name: Rebooting on Raspbian 
   shell: reboot now
   ignore_errors: true
-  when: ( boot_cmdline | changed )
+  when: ( boot_cmdline is changed )
           and
         ( ansible_facts.architecture is search("arm") )


### PR DESCRIPTION
Closes #1729.

This PR is necessary to make the 'Rebooting on Raspbian' task work at all; without the change the task silently fails on every run, regardless of architecture.﻿
