### PR TITLE
Fix typo in Ansible README file scp command.

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -49,6 +49,6 @@ ansible-playbook site.yml -i inventory/hosts.ini
 To get access to your **Kubernetes** cluster just
 
 ```bash
-scp debian@master_pi:~/kube/config ~/.kube/config
+scp debian@master_pi:~/.kube/config ~/.kube/config
 ```
 


### PR DESCRIPTION
When I was setting up my cluster, I got to the point where the Ansible README recommends copying down the kubeconfig file from the master server, but the command fails because the path is incorrect. It should be ~/.kube/config and not ~/kube/config (note the missing '.').﻿
