### PR TITLE
Fixes #1732: Use Ansible reboot module when rebooting ARM.

### DIFF
--- a/contrib/ansible/roles/raspbian/tasks/main.yml
+++ b/contrib/ansible/roles/raspbian/tasks/main.yml
@@ -17,8 +17,7 @@
   register: boot_cmdline
 
 - name: Rebooting on Raspbian 
-  shell: reboot now
-  ignore_errors: true
+  reboot:
   when: ( boot_cmdline | changed )
           and
         ( ansible_facts.architecture is search("arm") )


### PR DESCRIPTION
Closes #1732.

Use the 'reboot' module instead of a shell command to reboot ARM servers.﻿
