### PR TITLE
Add supervisor port

### DIFF
--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/google/tcpproxy"
-	"github.com/rancher/k3s/pkg/cli/cmds"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,14 +28,11 @@ type LoadBalancer struct {
 }
 
 const (
-	serviceName = "k3s-agent-load-balancer"
+	SupervisorServiceName = "k3s-agent-load-balancer"
+	APIServerServiceName  = "k3s-api-server-agent-load-balancer"
 )
 
-func Setup(ctx context.Context, cfg cmds.Agent) (_lb *LoadBalancer, _err error) {
-	if cfg.DisableLoadBalancer {
-		return nil, nil
-	}
-
+func New(dataDir, serviceName, serverURL string) (_lb *LoadBalancer, _err error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	defer func() {
 		if _err != nil {
@@ -51,18 +47,18 @@ func Setup(ctx context.Context, cfg cmds.Agent) (_lb *LoadBalancer, _err error) 
 	}
 	localAddress := listener.Addr().String()
 
-	originalServerAddress, localServerURL, err := parseURL(cfg.ServerURL, localAddress)
+	originalServerAddress, localServerURL, err := parseURL(serverURL, localAddress)
 	if err != nil {
 		return nil, err
 	}
 
 	lb := &LoadBalancer{
 		dialer:                &net.Dialer{},
-		configFile:            filepath.Join(cfg.DataDir, "etc", serviceName+".json"),
+		configFile:            filepath.Join(dataDir, "etc", serviceName+".json"),
 		localAddress:          localAddress,
 		localServerURL:        localServerURL,
 		originalServerAddress: originalServerAddress,
-		ServerURL:             cfg.ServerURL,
+		ServerURL:             serverURL,
 	}
 
 	lb.setServers([]string{lb.originalServerAddress})

--- a/pkg/agent/loadbalancer/loadbalancer_test.go
+++ b/pkg/agent/loadbalancer/loadbalancer_test.go
@@ -106,7 +106,7 @@ func TestFailOver(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := Setup(context.Background(), cfg)
+	lb, err := New(context.Background(), cfg.DataDir, SupervisorServiceName, cfg.ServerURL)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}
@@ -157,7 +157,7 @@ func TestFailFast(t *testing.T) {
 		DataDir:   tmpDir,
 	}
 
-	lb, err := Setup(context.Background(), cfg)
+	lb, err := New(context.Background(), cfg.DataDir, SupervisorServiceName, cfg.ServerURL)
 	if err != nil {
 		assertEqual(t, err, nil)
 	}

--- a/pkg/agent/proxy/apiproxy.go
+++ b/pkg/agent/proxy/apiproxy.go
@@ -1,0 +1,133 @@
+package proxy
+
+import (
+	sysnet "net"
+	"net/url"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/k3s/pkg/agent/loadbalancer"
+)
+
+type Proxy interface {
+	Update(addresses []string)
+	StartAPIServerProxy(port int) error
+	SupervisorURL() string
+	SupervisorAddresses() []string
+	APIServerURL() string
+}
+
+func NewAPIProxy(enabled bool, dataDir, supervisorURL string) (Proxy, error) {
+	p := &proxy{
+		lbEnabled:            enabled,
+		dataDir:              dataDir,
+		initialSupervisorURL: supervisorURL,
+		supervisorURL:        supervisorURL,
+		apiServerURL:         supervisorURL,
+	}
+
+	if enabled {
+		lb, err := loadbalancer.New(dataDir, loadbalancer.SupervisorServiceName, supervisorURL)
+		if err != nil {
+			return nil, err
+		}
+		p.supervisorLB = lb
+		p.supervisorURL = lb.LoadBalancerServerURL()
+		p.apiServerURL = p.supervisorURL
+	}
+
+	u, err := url.Parse(p.initialSupervisorURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse %s", p.initialSupervisorURL)
+	}
+	p.fallbackSupervisorAddress = u.Host
+	p.supervisorPort = u.Port()
+
+	return p, nil
+}
+
+type proxy struct {
+	dataDir   string
+	lbEnabled bool
+
+	initialSupervisorURL      string
+	supervisorURL             string
+	supervisorPort            string
+	fallbackSupervisorAddress string
+	supervisorAddresses       []string
+	supervisorLB              *loadbalancer.LoadBalancer
+
+	apiServerURL     string
+	apiServerLB      *loadbalancer.LoadBalancer
+	apiServerEnabled bool
+}
+
+func (p *proxy) Update(addresses []string) {
+	apiServerAddresses := addresses
+	supervisorAddresses := addresses
+
+	if p.apiServerEnabled {
+		supervisorAddresses = p.setSupervisorPort(supervisorAddresses)
+	}
+
+	if p.apiServerLB != nil {
+		p.apiServerLB.Update(apiServerAddresses)
+	}
+	if p.supervisorLB != nil {
+		p.supervisorLB.Update(supervisorAddresses)
+	}
+
+	p.supervisorAddresses = supervisorAddresses
+}
+
+func (p *proxy) setSupervisorPort(addresses []string) []string {
+	var newAddresses []string
+	for _, address := range addresses {
+		h, _, err := sysnet.SplitHostPort(address)
+		if err != nil {
+			logrus.Errorf("failed to parse address %s, dropping: %v", address, err)
+			continue
+		}
+		newAddresses = append(newAddresses, sysnet.JoinHostPort(h, p.supervisorPort))
+	}
+	return newAddresses
+}
+
+func (p *proxy) StartAPIServerProxy(port int) error {
+	u, err := url.Parse(p.initialSupervisorURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse server URL %s", p.initialSupervisorURL)
+	}
+	u.Host = sysnet.JoinHostPort(u.Hostname(), strconv.Itoa(port))
+
+	p.apiServerURL = u.String()
+	p.apiServerEnabled = true
+
+	if p.lbEnabled {
+		lb, err := loadbalancer.New(p.dataDir, loadbalancer.APIServerServiceName, p.apiServerURL)
+		if err != nil {
+			return err
+		}
+		p.apiServerURL = lb.LoadBalancerServerURL()
+		p.apiServerLB = lb
+	}
+
+	return nil
+}
+
+func (p *proxy) SupervisorURL() string {
+	return p.supervisorURL
+}
+
+func (p *proxy) SupervisorAddresses() []string {
+	if len(p.supervisorAddresses) > 0 {
+		return p.supervisorAddresses
+	}
+	return []string{p.fallbackSupervisorAddress}
+}
+
+func (p *proxy) APIServerURL() string {
+	return p.apiServerURL
+}

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -9,16 +9,22 @@ const (
 )
 
 type Server struct {
-	ClusterCIDR              string
-	AgentToken               string
-	AgentTokenFile           string
-	Token                    string
-	TokenFile                string
-	ClusterSecret            string
-	ServiceCIDR              string
-	ClusterDNS               string
-	ClusterDomain            string
-	HTTPSPort                int
+	ClusterCIDR    string
+	AgentToken     string
+	AgentTokenFile string
+	Token          string
+	TokenFile      string
+	ClusterSecret  string
+	ServiceCIDR    string
+	ClusterDNS     string
+	ClusterDomain  string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
 	DataDir                  string
 	DisableAgent             bool
 	KubeConfigOutput         string

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -83,7 +83,10 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.Rootless = cfg.Rootless
 	serverConfig.ControlConfig.SANs = knownIPs(cfg.TLSSan)
 	serverConfig.ControlConfig.BindAddress = cfg.BindAddress
+	serverConfig.ControlConfig.SupervisorPort = cfg.SupervisorPort
 	serverConfig.ControlConfig.HTTPSPort = cfg.HTTPSPort
+	serverConfig.ControlConfig.APIServerPort = cfg.APIServerPort
+	serverConfig.ControlConfig.APIServerBindAddress = cfg.APIServerBindAddress
 	serverConfig.ControlConfig.ExtraAPIArgs = cfg.ExtraAPIArgs
 	serverConfig.ControlConfig.ExtraControllerArgs = cfg.ExtraControllerArgs
 	serverConfig.ControlConfig.ExtraSchedulerAPIArgs = cfg.ExtraSchedulerArgs
@@ -102,6 +105,10 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	serverConfig.ControlConfig.ClusterInit = cfg.ClusterInit
 	serverConfig.ControlConfig.ClusterReset = cfg.ClusterReset
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets
+
+	if serverConfig.ControlConfig.SupervisorPort == 0 {
+		serverConfig.ControlConfig.SupervisorPort = serverConfig.ControlConfig.HTTPSPort
+	}
 
 	if cmds.AgentConfig.FlannelIface != "" && cmds.AgentConfig.NodeIP == "" {
 		cmds.AgentConfig.NodeIP = netutil.GetIPFromInterface(cmds.AgentConfig.FlannelIface)
@@ -201,7 +208,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		ip = "127.0.0.1"
 	}
 
-	url := fmt.Sprintf("https://%s:%d", ip, serverConfig.ControlConfig.HTTPSPort)
+	url := fmt.Sprintf("https://%s:%d", ip, serverConfig.ControlConfig.SupervisorPort)
 	token, err := server.FormatToken(serverConfig.ControlConfig.Runtime.AgentToken, serverConfig.ControlConfig.Runtime.ServerCA)
 	if err != nil {
 		return err

--- a/pkg/clientaccess/clientaccess.go
+++ b/pkg/clientaccess/clientaccess.go
@@ -148,7 +148,7 @@ func ParseAndValidateToken(server, token string) (*Info, error) {
 }
 
 func validateToken(u url.URL, cacerts []byte, username, password string) error {
-	u.Path = "/apis"
+	u.Path = "/cacerts"
 	_, err := get(u.String(), GetHTTPClient(cacerts), username, password)
 	if err != nil {
 		return errors.Wrap(err, "token is not valid")

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, error) {
-	tcp, err := dynamiclistener.NewTCPListener(c.config.BindAddress, c.config.HTTPSPort)
+	tcp, err := dynamiclistener.NewTCPListener(c.config.BindAddress, c.config.SupervisorPort)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -34,7 +34,6 @@ type Node struct {
 	Images                   string
 	AgentConfig              Agent
 	CACerts                  []byte
-	ServerAddress            string
 	Certificate              *tls.Certificate
 }
 
@@ -85,12 +84,17 @@ type Agent struct {
 }
 
 type Control struct {
-	AdvertisePort            int
-	AdvertiseIP              string
-	ListenPort               int
-	HTTPSPort                int
-	AgentToken               string
-	Token                    string
+	AdvertisePort int
+	AdvertiseIP   string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	AgentToken               string `json:"-"`
+	Token                    string `json:"-"`
 	ClusterIPRange           *net.IPNet
 	ServiceIPRange           *net.IPNet
 	ClusterDNS               net.IP

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -223,7 +223,7 @@ func printTokens(advertiseIP string, config *config.Control) error {
 	}
 
 	if len(nodeFile) > 0 {
-		printToken(config.HTTPSPort, advertiseIP, "To join node to cluster:", "agent")
+		printToken(config.SupervisorPort, advertiseIP, "To join node to cluster:", "agent")
 	}
 
 	return nil

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -9,4 +9,5 @@ type Config struct {
 	DisableServiceLB bool
 	ControlConfig    config.Control
 	Rootless         bool
+	SupervisorPort   int
 }


### PR DESCRIPTION
In k3s today the kubernetes API and the /v1-k3s API are combined into
one http server.  In rke2 we are running unmodified, non-embedded Kubernetes
and as such it is preferred to run k8s and the /v1-k3s API on different
ports.  The /v1-k3s API port is called the SupervisorPort in the code.

To support this separation of ports a new shim was added on the client in
then pkg/agent/proxy package that will launch two load balancers instead
of just one load balancer.  One load balancer for 6443 and the other
for 9345 (which is the supervisor port).