### PR TITLE
Feature Request #1741: Adding support for tls minimum version

### DIFF
--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -33,7 +33,9 @@ func (c *Cluster) newListener(ctx context.Context) (net.Listener, http.Handler, 
 		CN:           "k3s",
 		Organization: []string{"k3s"},
 		TLSConfig: tls.Config{
-			ClientAuth: tls.RequestClientCert,
+			ClientAuth:   tls.RequestClientCert,
+			MinVersion:   c.config.TLSMinVersion,
+			CipherSuites: c.config.TLSCipherSuites,
 		},
 		SANs: append(c.config.SANs, "localhost", "kubernetes", "kubernetes.default", "kubernetes.default.svc."+c.config.ClusterDomain),
 	})

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -122,6 +122,8 @@ type Control struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	EncryptSecrets           bool
+	TLSMinVersion            uint16
+	TLSCipherSuites          []uint16
 
 	BindAddress string
 	SANs        []string


### PR DESCRIPTION
Adding support for TLS MinVersion and CipherSuites and set to VersionTLS12 by default

This will watch for the following kube-apiserver-arg variables and apply them to the k3s kube-apiserver https listener.
    
      --kube-apiserver-arg=tls-cipher-suites=XXXXXXX
      --kube-apiserver-arg=tls-min-version=XXXXXXX

Closes #1741 #768

This allows the kubeapi server to run with a secure version of TLS.  Without this change there is no way to disable the insecure versions of TLS. 

The default version can be changed to VersionTLS10 if there is a desire to continue with the current insecure default.