### PR TITLE
Configure default signer implementation to use ClientCA instead of ServerCA

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -131,8 +131,8 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		"bind-address":                     localhostIP.String(),
 		"secure-port":                      "0",
 		"use-service-account-credentials":  "true",
-		"cluster-signing-cert-file":        runtime.ServerCA,
-		"cluster-signing-key-file":         runtime.ServerCAKey,
+		"cluster-signing-cert-file":        runtime.ClientCA,
+		"cluster-signing-key-file":         runtime.ClientCAKey,
 	}
 	if cfg.NoLeaderElect {
 		argsMap["leader-elect"] = "false"


### PR DESCRIPTION
Certificates issued by the signer controller should be issued by the k3s ClientCA instead of the ServerCA so that they are trusted by kube-apiserver, as guaranteed by [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers). 

Fixes rancher/k3s#1764

~~While this fixes the reported issue and allows proper issuance of client certificates, I'm not 100% sure that this is the right way to resolve the issue, as it makes the signer controller unable to issue certs that are trusted as servers.~~

~~The correct fix (as mentioned in the issue) is probably to have a master Root CA that issues the ClientCA, ServerCA, and (new) SignerCA keys. This would provide a single trust anchor between all components.~~