### PR TITLE
Replace new string creation with strings.builder

### DIFF
--- a/pkg/agent/loadbalancer/utility.go
+++ b/pkg/agent/loadbalancer/utility.go
@@ -8,6 +8,7 @@ import (
 )
 
 func parseURL(serverURL, newHost string) (string, string, error) {
+	var address strings.Builder
 	parsedURL, err := url.Parse(serverURL)
 	if err != nil {
 		return "", "", err
@@ -15,17 +16,17 @@ func parseURL(serverURL, newHost string) (string, string, error) {
 	if parsedURL.Host == "" {
 		return "", "", errors.New("Initial server URL host is not defined for load balancer")
 	}
-	address := parsedURL.Host
+	address.WriteString(parsedURL.Host)
 	if parsedURL.Port() == "" {
 		if strings.ToLower(parsedURL.Scheme) == "http" {
-			address += ":80"
+			address.WriteString(":80")
 		}
 		if strings.ToLower(parsedURL.Scheme) == "https" {
-			address += ":443"
+			address.WriteString(":443")
 		}
 	}
 	parsedURL.Host = newHost
-	return address, parsedURL.String(), nil
+	return address.String(), parsedURL.String(), nil
 }
 
 func sortServers(input []string, search string) ([]string, bool) {

--- a/pkg/agent/netpol/utils.go
+++ b/pkg/agent/netpol/utils.go
@@ -358,14 +358,14 @@ func parseIPSetSave(ipset *IPSet, result string) map[string]*Set {
 // create KUBE-DST-3YNVZWWGX3UQQ4VQ hash:ip family inet hashsize 1024 maxelem 65536 timeout 0
 // add KUBE-DST-3YNVZWWGX3UQQ4VQ 100.96.1.6 timeout 0
 func buildIPSetRestore(ipset *IPSet) string {
-	ipSetRestore := ""
+	var ipSetRestore strings.Builder
 	for _, set := range ipset.Sets {
-		ipSetRestore += fmt.Sprintf("create %s %s\n", set.Name, strings.Join(set.Options[:], " "))
+		ipSetRestore.WriteString(fmt.Sprintf("create %s %s\n", set.Name, strings.Join(set.Options[:], " ")))
 		for _, entry := range set.Entries {
-			ipSetRestore += fmt.Sprintf("add %s %s\n", set.Name, strings.Join(entry.Options[:], " "))
+			ipSetRestore.WriteString(fmt.Sprintf("add %s %s\n", set.Name, strings.Join(entry.Options[:], " ")))
 		}
 	}
-	return ipSetRestore
+	return ipSetRestore.String()
 }
 
 // Save the given set, or all sets if none is given to stdout in a format that

--- a/pkg/daemons/control/tunnel.go
+++ b/pkg/daemons/control/tunnel.go
@@ -23,13 +23,14 @@ func setupTunnel() http.Handler {
 func setupProxyDialer(tunnelServer *remotedialer.Server) {
 	app.DefaultProxyDialerFn = utilnet.DialFunc(func(ctx context.Context, network, address string) (net.Conn, error) {
 		_, port, _ := net.SplitHostPort(address)
-		addr := "127.0.0.1"
+		var addr strings.Builder
+		addr.WriteString("127.0.0.1")
 		if port != "" {
-			addr += ":" + port
+			addr.WriteString(":" + port)
 		}
 		nodeName, _ := kv.Split(address, ":")
 		if tunnelServer.HasSession(nodeName) {
-			return tunnelServer.Dial(nodeName, 15*time.Second, "tcp", addr)
+			return tunnelServer.Dial(nodeName, 15*time.Second, "tcp", addr.String())
 		}
 		var d net.Dialer
 		return d.DialContext(ctx, network, address)

--- a/pkg/node/controller.go
+++ b/pkg/node/controller.go
@@ -39,7 +39,7 @@ func (h *handler) onRemove(key string, node *core.Node) (*core.Node, error) {
 
 func (h *handler) updateHosts(node *core.Node, removed bool) (*core.Node, error) {
 	var (
-		newHosts    string
+		newHosts    strings.Builder
 		nodeAddress string
 		hostsMap    map[string]string
 	)
@@ -90,9 +90,9 @@ func (h *handler) updateHosts(node *core.Node, removed bool) (*core.Node, error)
 		hostsMap[node.Name] = nodeAddress
 	}
 	for host, ip := range hostsMap {
-		newHosts += ip + " " + host + "\n"
+		newHosts.WriteString(ip + " " + host + "\n")
 	}
-	configMap.Data["NodeHosts"] = newHosts
+	configMap.Data["NodeHosts"] = newHosts.String()
 
 	if _, err := h.configClient.Update(configMap); err != nil {
 		return nil, err


### PR DESCRIPTION
Given the IOT/edge use cases for k3s, I saw some room for memory efficiency by replacing instances of `+=` with `strings.Builder` which will lessen the amount of copies of strings being built in memory.