### PR TITLE
Create a "current" symlink to artifact dir in DataDir

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -139,8 +139,9 @@ func extract(dataDir string) (string, error) {
 	}
 
 	currentSymLink := filepath.Join(dataDir, "data", "current")
+	previousSymLink := filepath.Join(dataDir, "data", "previous")
 	if _, err := os.Lstat(currentSymLink); err == nil {
-		if err := os.Rename(currentSymLink, currentSymLink+".prev"); err != nil {
+		if err := os.Rename(currentSymLink, previousSymLink); err != nil {
 			return "", err
 		}
 	}

--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -138,5 +138,15 @@ func extract(dataDir string) (string, error) {
 		return "", err
 	}
 
+	currentSymLink := filepath.Join(dataDir, "data", "current")
+	if _, err := os.Lstat(currentSymLink); err == nil {
+		if err := os.Rename(currentSymLink, currentSymLink+".prev"); err != nil {
+			return "", err
+		}
+	}
+	if err := os.Symlink(dir, currentSymLink); err != nil {
+		return "", err
+	}
+
 	return dir, os.Rename(tempDest, dir)
 }


### PR DESCRIPTION
Hi,

This PR creates a symbolic link named `current` to the active k3s version artifact dir in `DataDir`. It renames the previous one if it exists.

This is useful for example to install multus CNI that relies on CNI binaries, and look for them by default in `/opt/cni/bin`. Even if we can override this, we would need to know the artifcat dir name at install, and it would not work after a k3s upgrade.

With the current artefact dir symlink, we can either point to `/var/lib/rancher/k3s/data/current/bin`, or create binaries symlinks in `/opt/cni/bin` to the required binaries in `/var/lib/rancher/k3s/data/current/bin`.

Regards,

Ben.


