### PR TITLE
Bump stable version from v1.17.4 to v1.18.2

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.17.4+k3s1
+  latest: v1.18.2+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
* Updates channel.yaml - replaces v1.17.4 with v1.18.2 which is now stable.