### PR TITLE
Add retry backoff for starting network-policy controller

### DIFF
--- a/pkg/agent/netpol/network_policy.go
+++ b/pkg/agent/netpol/network_policy.go
@@ -8,8 +8,12 @@ import (
 
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 )
 
 func Run(ctx context.Context, nodeConfig *config.Node) error {
@@ -26,6 +30,21 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
+	}
+
+	// retry backoff to wait for the clusterrolebinding of user "system:k3s-controller"
+	retryBackoff := wait.Backoff{
+		Steps:    6,
+		Duration: 100 * time.Millisecond,
+		Factor:   3.0,
+		Cap:      30 * time.Second,
+	}
+	retryErr := retry.OnError(retryBackoff, errors.IsForbidden, func() error {
+		_, err := client.NetworkingV1().NetworkPolicies("").List(ctx, metav1.ListOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return retryErr
 	}
 
 	npc, err := NewNetworkPolicyController(ctx.Done(), client, time.Minute, nodeConfig.AgentConfig.NodeName)


### PR DESCRIPTION
This network-policy controller runs in the k3s agent, it needs the `system:k3s-controller` user to list pods, namespaces, and network-policies. We can get the RABC info in the `/var/lib/rancher/k3s/server/manifests`. 

There is a race-condition that the network-policy controller should run after the clusterrolebinding. When using containerd, the agent waits for containerd to start, which gives the server time to load clusterrolebinding. If using docker, the agent will start faster. At that moment, it is likely that the server has not loaded clusterrolebinding.

Related issues:
- https://github.com/rancher/k3s/issues/1792
- https://github.com/rancher/k3s/issues/1551