### PR TITLE
feat(install): replace rpm by yum for setup_selinux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -415,7 +415,7 @@ setup_binary() {
 setup_selinux() {
     policy_hint="please install:
     yum install -y container-selinux selinux-policy-base
-    rpm -i https://rpm.rancher.io/k3s-selinux-0.1.1-rc1.el7.noarch.rpm
+    yum install -y https://rpm.rancher.io/k3s-selinux-0.1.1-rc1.el7.noarch.rpm
 "
     policy_error=fatal
     if [ "$INSTALL_K3S_SELINUX_WARN" = true ]; then


### PR DESCRIPTION
It's a bad practice to install packages via rpm directly. It's better to install all packages with Yum/Dnf. It's also possible to install packages directly via an URL, which is the purpose of this PR.