### PR TITLE
Listen insecurely on localhost only

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -131,6 +131,7 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		"root-ca-file":                     runtime.ServerCA,
 		"port":                             "10252",
 		"profiling":                        "false",
+		"address":                          localhostIP.String(),
 		"bind-address":                     localhostIP.String(),
 		"secure-port":                      "0",
 		"use-service-account-credentials":  "true",
@@ -151,6 +152,7 @@ func scheduler(cfg *config.Control, runtime *config.ControlRuntime) error {
 	argsMap := map[string]string{
 		"kubeconfig":   runtime.KubeConfigScheduler,
 		"port":         "10251",
+		"address":      "127.0.0.1",
 		"bind-address": "127.0.0.1",
 		"secure-port":  "0",
 		"profiling":    "false",


### PR DESCRIPTION
Before this change, k3s configured the scheduler and controller's
insecure ports to listen on 0.0.0.0. Those ports include pprof, which
provides a minor DoS vector.

These ports are only enabled for componentstatus checks in the first
place, and componentstatus is hardcoded to only do the check on
localhost anyway (see
https://github.com/kubernetes/kubernetes/blob/v1.18.2/pkg/registry/core/rest/storage_core.go#L341-L344),
so there shouldn't be any downside to switching them to listen only on
localhost.