### PR TITLE
Update stable channel to v1.18.3+k3s1

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.18.2+k3s1
+  latest: v1.18.3+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
* This version of k3s addresses two CVEs -- Please reference the release notes