### PR TITLE
add tls-sans to api-server cert

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -570,7 +570,7 @@ func genServerCerts(config *config.Control, runtime *config.ControlRuntime) erro
 
 	if _, err := createClientCertKey(regen, "kube-apiserver", nil,
 		&certutil.AltNames{
-			DNSNames: []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"},
+			DNSNames: append([]string{"kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}, config.SANs...),
 			IPs:      []net.IP{apiServerServiceIP, localhostIP},
 		}, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		runtime.ServerCA, runtime.ServerCAKey,


### PR DESCRIPTION
Add TLS sans to api server cert. This seems to be related to https://github.com/rancher/k3s/issues/1452
