### PR TITLE
containerd: swap in k3c daemon [wip]

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -34,9 +34,9 @@ const (
 
 func Run(ctx context.Context, cfg *config.Node) error {
 	args := []string{
-		"containerd",
-		"-c", cfg.Containerd.Config,
-		"-a", cfg.Containerd.Address,
+		"k3c", "daemon", "--cni-bin=" + cfg.AgentConfig.CNIBinDir,
+		"--config", cfg.Containerd.Config,
+		"--address", cfg.Containerd.Address,
 		"--state", cfg.Containerd.State,
 		"--root", cfg.Containerd.Root,
 	}

--- a/scripts/download
+++ b/scripts/download
@@ -6,6 +6,7 @@ cd $(dirname $0)/..
 
 ROOT_VERSION=v0.4.1
 TRAEFIK_VERSION=1.81.0
+K3C_VERSION=v0.2.1
 CHARTS_DIR=build/static/charts
 
 mkdir -p ${CHARTS_DIR}
@@ -21,3 +22,6 @@ TRAEFIK_FILE=traefik-${TRAEFIK_VERSION}.tgz
 curl -sfL https://kubernetes-charts.storage.googleapis.com/${TRAEFIK_FILE} -o ${CHARTS_DIR}/${TRAEFIK_FILE}
 
 cp scripts/wg-add.sh bin/aux/
+
+curl -fsSL https://github.com/rancher/k3c/releases/download/${K3C_VERSION}/k3c-linux-${ARCH} --output bin/k3c
+chmod +x bin/k3c


### PR DESCRIPTION
outstanding issues:
- [ ] k3c still pulls the bootstrap container when it should detect that it is not necessary (due to missing runc v1 shim)