### PR TITLE
Enable rotatekubeletservercertificate in Kubelet and ControllerManager

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -67,6 +67,7 @@ func startKubelet(cfg *config.Agent) error {
 		"authentication-token-webhook": "true",
 		"anonymous-auth":               "false",
 		"authorization-mode":           modes.ModeWebhook,
+		"feature-gates":                "RotateKubeletServerCertificate=true",
 	}
 	if cfg.PodManifests != "" && argsMap["pod-manifest-path"] == "" {
 		argsMap["pod-manifest-path"] = cfg.PodManifests

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -135,6 +135,7 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		"use-service-account-credentials":  "true",
 		"cluster-signing-cert-file":        runtime.ServerCA,
 		"cluster-signing-key-file":         runtime.ServerCAKey,
+		"feature-gates":                    "RotateKubeletServerCertificate=true",
 	}
 	if cfg.NoLeaderElect {
 		argsMap["leader-elect"] = "false"


### PR DESCRIPTION
Enables the feature-gate RotateKubeletServerCertificate in Kubelet and ControllerManager to remediate issues found when running the CIS 1.5 benchmark.