### PR TITLE
Implement new k3s-root changes

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -4,18 +4,13 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-ROOT_VERSION=v0.4.1
+ROOT_VERSION=v0.5.0
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
 
 mkdir -p ${CHARTS_DIR}
 
 curl --compressed -sfL https://github.com/rancher/k3s-root/releases/download/${ROOT_VERSION}/k3s-root-${ARCH}.tar | tar xf -
-ln -sf pigz bin/unpigz
-for target in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-  ln -sf xtables-legacy-multi bin/$target
-done
-mkdir -p bin/aux && rm bin/mount && ln -sf ../busybox bin/aux/mount
 
 TRAEFIK_FILE=traefik-${TRAEFIK_VERSION}.tgz
 curl -sfL https://kubernetes-charts.storage.googleapis.com/${TRAEFIK_FILE} -o ${CHARTS_DIR}/${TRAEFIK_FILE}


### PR DESCRIPTION
`k3s-root` v0.5.0 implements the new iptables-detect script. This PR changes the `scripts/download` file to better consume `k3s-root` as the various symbolic link creation commands were moved into the `k3s-root` build process.