### PR TITLE
Create Symlink from docker Sock When --docker Flag Issued

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -42,6 +42,12 @@ var (
 func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	nodeConfig := config.Get(ctx, cfg, proxy)
 
+	if cfg.Docker {
+		if err := os.Symlink("/var/run/dockershim.sock", "/run/k3s/containerd/containerd.sock"); err != nil {
+			return err
+		}
+	}
+
 	if !nodeConfig.NoFlannel {
 		if err := flannel.Prepare(ctx, nodeConfig); err != nil {
 			return err


### PR DESCRIPTION
This pull request fixes an issue brought to light in #1582 . If the docker flag is given, we create a symlink from the docker socket file to where the k3s packages crictl binary expects the socket to be.