### PR TITLE
Make packaged crictl work when using Docker

### DIFF
--- a/cmd/k3s/main.go
+++ b/cmd/k3s/main.go
@@ -40,6 +40,9 @@ func main() {
 }
 
 func runCLIs() bool {
+	if os.Getenv("CRI_CONFIG_FILE") == "" {
+		os.Setenv("CRI_CONFIG_FILE", datadir.DefaultDataDir+"/agent/etc/crictl.yaml")
+	}
 	for _, cmd := range []string{"kubectl", "ctr", "crictl"} {
 		if filepath.Base(os.Args[0]) == cmd {
 			if err := externalCLI(cmd, "", os.Args[1:]); err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -42,6 +42,12 @@ var (
 func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	nodeConfig := config.Get(ctx, cfg, proxy)
 
+	if cfg.Docker {
+		if err := os.Symlink("/var/run/dockershim.sock", "/run/k3s/containerd/containerd.sock"); err != nil {
+			return err
+		}
+	}
+
 	if !nodeConfig.NoFlannel {
 		if err := flannel.Prepare(ctx, nodeConfig); err != nil {
 			return err

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/k3s/pkg/clientaccess"
 	"github.com/rancher/k3s/pkg/daemons/agent"
 	daemonconfig "github.com/rancher/k3s/pkg/daemons/config"
+	"github.com/rancher/k3s/pkg/datadir"
 	"github.com/rancher/k3s/pkg/nodeconfig"
 	"github.com/rancher/k3s/pkg/rootless"
 	"github.com/rancher/k3s/pkg/version"
@@ -39,13 +40,40 @@ var (
 	HostnameLabel   = version.Program + ".io/hostname"
 )
 
+const (
+	dockershimSock = "unix:///var/run/dockershim.sock"
+	containerdSock = "unix:///run/k3s/containerd/containerd.sock"
+)
+
+// setupCriCtlConfig creates the crictl config file and populates it
+// with the given data from config.
+func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *daemonconfig.Node) error {
+	cre := nodeConfig.ContainerRuntimeEndpoint
+	if cre == "" {
+		switch {
+		case cfg.Docker:
+			cre = dockershimSock
+		default:
+			cre = containerdSock
+		}
+	}
+
+	agentConfDir := datadir.DefaultDataDir + "/agent/etc"
+	if _, err := os.Stat(agentConfDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(agentConfDir, 0755); err != nil {
+			return err
+		}
+	}
+
+	crp := "runtime-endpoint: " + cre + "\n"
+	return ioutil.WriteFile(agentConfDir+"/crictl.yaml", []byte(crp), 0600)
+}
+
 func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	nodeConfig := config.Get(ctx, cfg, proxy)
 
-	if cfg.Docker {
-		if err := os.Symlink("/var/run/dockershim.sock", "/run/k3s/containerd/containerd.sock"); err != nil {
-			return err
-		}
+	if err := setupCriCtlConfig(cfg, nodeConfig); err != nil {
+		return err
 	}
 
 	if !nodeConfig.NoFlannel {


### PR DESCRIPTION
This pull request fixes an issue brought to light in #1582 . We're creating a config file for crictl and populating it with either the default containerd sock file path or if the docker flag is issued, we update it to use the dockershim socket path.