### PR TITLE
Perform basic validation on K3S_URL in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,9 +153,14 @@ setup_env() {
                 if [ -z "${K3S_TOKEN}" ] && [ -z "${K3S_CLUSTER_SECRET}" ]; then
                     fatal "Defaulted k3s exec command to 'agent' because K3S_URL is defined, but K3S_TOKEN or K3S_CLUSTER_SECRET is not defined."
                 fi
-                if ! echo "${K3S_URL}" | grep -q "^https://"; then
-                    fatal "Only https:// URLs are supported for K3S_URL (have ${K3S_URL})"
-                fi
+
+                case "${K3S_URL}" in
+                    https://*)
+                        ;;
+                    *)
+                        fatal "Only https:// URLs are supported for K3S_URL (have ${K3S_URL})"
+                        ;;
+                esac
                 CMD_K3S=agent
             fi
         ;;

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,9 @@ setup_env() {
                 if [ -z "${K3S_TOKEN}" ] && [ -z "${K3S_CLUSTER_SECRET}" ]; then
                     fatal "Defaulted k3s exec command to 'agent' because K3S_URL is defined, but K3S_TOKEN or K3S_CLUSTER_SECRET is not defined."
                 fi
+                if ! echo "${K3S_URL}" | grep -q "^https://"; then
+                    fatal "Only https:// URLs are supported for K3S_URL (have ${K3S_URL})"
+                fi
                 CMD_K3S=agent
             fi
         ;;


### PR DESCRIPTION
This allows us to fail quickly if we're handed a schemeless or plain
HTTP URI, rather than having the agent barf when the systemd unit
starts. For an operator, this makes for a cleaner error up front and
clear messaging for how to fix the situation.

Addresses #1964 

Signed-off-by: Josh McSavaney <mcsaucy@csh.rit.edu>