### PR TITLE
fixed panic in network_policy_controller

### DIFF
--- a/pkg/agent/netpol/network_policy_controller.go
+++ b/pkg/agent/netpol/network_policy_controller.go
@@ -1693,7 +1693,11 @@ func NewNetworkPolicyController(
 	npc.syncPeriod = ipTablesSyncPeriod
 
 	npc.v1NetworkPolicy = true
-	v, _ := clientset.Discovery().ServerVersion()
+	v, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+
 	valid := regexp.MustCompile("[0-9]")
 	v.Minor = strings.Join(valid.FindAllString(v.Minor, -1), "")
 	minorVer, _ := strconv.Atoi(v.Minor)


### PR DESCRIPTION
reopened #1883 - i have singed commit.

    I have rebooted a newly created k3s etcd cluster and this panic was triggered:

    ```
    k3s[948]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x45f2945]
    k3s[948]: goroutine 1 [running]:
    k3s[948]: github.com/rancher/k3s/pkg/agent/netpol.NewNetworkPolicyController(0xc00159e180, 0x61b4a60, 0xc006294000, 0xdf8475800, 0xc011d9a360, 0xc, 0x0, 0xc00bf545b8, 0x2b2edbc)
    k3s[948]:         /home/x/git/k3s/pkg/agent/netpol/network_policy_controller.go:1698 +0x275
    ```
