### PR TITLE
Fix typo in toleration in klipper daemonset #1989

### DIFF
--- a/pkg/servicelb/controller.go
+++ b/pkg/servicelb/controller.go
@@ -357,9 +357,9 @@ func (h *handler) newDaemonSet(svc *core.Service) (*apps.DaemonSet, error) {
 		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, container)
 	}
 
-	// Add toleration to noderole.kubernetes.io/master=*:NoSchedule
+	// Add toleration to node-role.kubernetes.io/master=*:NoSchedule
 	noScheduleToleration := core.Toleration{
-		Key:      "noderole.kubernetes.io/master",
+		Key:      "node-role.kubernetes.io/master",
 		Operator: "Exists",
 		Effect:   "NoSchedule",
 	}


### PR DESCRIPTION
This fix the issue #1989 for allowing tainting control plane node with
```
node-role.kubernetes.io/master=effect:NoSchedule
```
