### PR TITLE
Add containerd snapshotter flag

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -423,7 +423,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 		nodeConfig.AgentConfig.RootDir = filepath.Join(envInfo.DataDir, "kubelet")
 	}
 	nodeConfig.AgentConfig.PauseImage = envInfo.PauseImage
-	nodeConfig.AgentConfig.SnapShotter = envInfo.SnapShotter
+	nodeConfig.AgentConfig.Snapshotter = envInfo.Snapshotter
 	nodeConfig.AgentConfig.IPSECPSK = controlConfig.IPSECPSK
 	nodeConfig.AgentConfig.StrongSwanDir = filepath.Join(envInfo.DataDir, "strongswan")
 	nodeConfig.CACerts = info.CACerts

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -423,6 +423,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 		nodeConfig.AgentConfig.RootDir = filepath.Join(envInfo.DataDir, "kubelet")
 	}
 	nodeConfig.AgentConfig.PauseImage = envInfo.PauseImage
+	nodeConfig.AgentConfig.SnapShotter = envInfo.SnapShotter
 	nodeConfig.AgentConfig.IPSECPSK = controlConfig.IPSECPSK
 	nodeConfig.AgentConfig.StrongSwanDir = filepath.Join(envInfo.DataDir, "strongswan")
 	nodeConfig.CACerts = info.CACerts

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -33,9 +33,9 @@ const ContainerdConfigTemplate = `
   sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
 {{end}}
 
-{{- if .NodeConfig.AgentConfig.SnapShotter }}
+{{- if .NodeConfig.AgentConfig.Snapshotter }}
 [plugins.cri.containerd]
-  snapshotter = "{{ .NodeConfig.AgentConfig.SnapShotter }}"
+  snapshotter = "{{ .NodeConfig.AgentConfig.Snapshotter }}"
 {{end}}
 
 {{- if not .NodeConfig.NoFlannel }}

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -33,6 +33,11 @@ const ContainerdConfigTemplate = `
   sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
 {{end}}
 
+{{- if .NodeConfig.AgentConfig.SnapShotter }}
+[plugins.cri.containerd]
+  snapshotter = "{{ .NodeConfig.AgentConfig.SnapShotter }}"
+{{end}}
+
 {{- if not .NodeConfig.NoFlannel }}
 [plugins.cri.cni]
   bin_dir = "{{ .NodeConfig.AgentConfig.CNIBinDir }}"

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -21,6 +21,7 @@ type Agent struct {
 	NodeExternalIP           string
 	NodeName                 string
 	PauseImage               string
+	SnapShotter              string
 	Docker                   bool
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
@@ -89,6 +90,12 @@ var (
 		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
 		Destination: &AgentConfig.PauseImage,
 		Value:       "docker.io/rancher/pause:3.1",
+	}
+	SnapShotterFlag = cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Customized containerd snapshotter",
+		Destination: &AgentConfig.SnapShotter,
+		Value:       "overlayfs",
 	}
 	FlannelFlag = cli.BoolFlag{
 		Name:        "no-flannel",
@@ -190,6 +197,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
 			&DisableSELinuxFlag,
 			&CRIEndpointFlag,
 			&PauseImageFlag,
+			&SnapShotterFlag,
 			&PrivateRegistryFlag,
 			&NodeIPFlag,
 			&NodeExternalIPFlag,

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -21,7 +21,7 @@ type Agent struct {
 	NodeExternalIP           string
 	NodeName                 string
 	PauseImage               string
-	SnapShotter              string
+	Snapshotter              string
 	Docker                   bool
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
@@ -91,10 +91,10 @@ var (
 		Destination: &AgentConfig.PauseImage,
 		Value:       "docker.io/rancher/pause:3.1",
 	}
-	SnapShotterFlag = cli.StringFlag{
+	SnapshotterFlag = cli.StringFlag{
 		Name:        "snapshotter",
-		Usage:       "(agent/runtime) Customized containerd snapshotter",
-		Destination: &AgentConfig.SnapShotter,
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
 		Value:       "overlayfs",
 	}
 	FlannelFlag = cli.BoolFlag{
@@ -197,7 +197,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
 			&DisableSELinuxFlag,
 			&CRIEndpointFlag,
 			&PauseImageFlag,
-			&SnapShotterFlag,
+			&SnapshotterFlag,
 			&PrivateRegistryFlag,
 			&NodeIPFlag,
 			&NodeExternalIPFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -238,7 +238,7 @@ func NewServerCommand(action func(*cli.Context) error) *cli.Command {
 			&DisableSELinuxFlag,
 			&CRIEndpointFlag,
 			&PauseImageFlag,
-			&SnapShotterFlag,
+			&SnapshotterFlag,
 			&PrivateRegistryFlag,
 			&NodeIPFlag,
 			&NodeExternalIPFlag,

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -238,6 +238,7 @@ func NewServerCommand(action func(*cli.Context) error) *cli.Command {
 			&DisableSELinuxFlag,
 			&CRIEndpointFlag,
 			&PauseImageFlag,
+			&SnapShotterFlag,
 			&PrivateRegistryFlag,
 			&NodeIPFlag,
 			&NodeExternalIPFlag,

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -72,6 +72,7 @@ type Agent struct {
 	ExtraKubeletArgs        []string
 	ExtraKubeProxyArgs      []string
 	PauseImage              string
+	SnapShotter             string
 	CNIPlugin               bool
 	NodeTaints              []string
 	NodeLabels              []string

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -72,7 +72,7 @@ type Agent struct {
 	ExtraKubeletArgs        []string
 	ExtraKubeProxyArgs      []string
 	PauseImage              string
-	SnapShotter             string
+	Snapshotter             string
 	CNIPlugin               bool
 	NodeTaints              []string
 	NodeLabels              []string


### PR DESCRIPTION
# Describe
rancher/k3s#924

In some scenarios, we need to change the Snapshotter for Containerd(such as Running K3s in Kata-Containers(9pfs)).

# How-to-Use
```
--snapshotter value                 (agent/runtime) Customized containerd snapshotter (default: "overlayfs")

k3s server --snapshotter=native
k3s agent --snapshotter=natvie
```




Signed-off-by: Jason-ZW <zhenyang@rancher.com>