### PR TITLE
backport 1.18 : Always keep restarting k3s process by openrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -689,6 +689,7 @@ error_log=${LOG_FILE}
 
 pidfile="/var/run/${SYSTEM_NAME}.pid"
 respawn_delay=5
+respawn_max=0
 
 set -o allexport
 if [ -f /etc/environment ]; then source /etc/environment; fi


### PR DESCRIPTION
**This is #1933 backported from master to `release-1.18`**

When for some reason, k3s crashes, and can't startup again, e.g. when
the data backend is not available (dqlite crashed, database server is
offline, ...), on openrc systems, supervise-daemon will try to restart
it, as per supervise-daemon(8):

    respawn-max:

    Sets the maximum number of times a daemon will be respawned during
    a respawn period. If a daemon dies more than this number of times
    during a respawn period, will give up trying to respawn it and exit.
    The default is 10, and 0 means unlimited.

Setting respawn-max to 0, makes sure a k3s process on openrc systems will
keep trying to come online, even if the database backend is offline for a
longer period of time.

This aligns the openrc service configuration with the systemd
configuration, which has

    Restart=always
    RestartSec=5s