### PR TITLE
remove hard coded value from ProgramUpper

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,7 +4,7 @@ import "strings"
 
 var (
 	Program      = "k3s"
-	ProgramUpper = strings.ToUpper("k3s")
+	ProgramUpper = strings.ToUpper(Program)
 	Version      = "dev"
 	GitCommit    = "HEAD"
 )


### PR DESCRIPTION
This PR removes the hard coded value that was being passed in to ProgramUpper in favor of the Program variable. This is needed to resolve an issue with environment variable use in RKE2.