### PR TITLE
Set v1.18.6 as stable in channel server

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.18.4+k3s1
+  latest: v1.18.6+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
Update channel.yaml so v1.18.6 is now our stable version in the channel server.

Is for https://github.com/rancher/k3s/issues/2021