### PR TITLE
add protect-kernel-defaults to kubelet

### DIFF
--- a/pkg/cli/agent/agent.go
+++ b/pkg/cli/agent/agent.go
@@ -56,6 +56,7 @@ func Run(ctx *cli.Context) error {
 	cfg := cmds.AgentConfig
 	cfg.Debug = ctx.Bool("debug")
 	cfg.DataDir = dataDir
+	cfg.ProtectKernelDefaults = true
 
 	contextCtx := signals.SetupSignalHandler(context.Background())
 

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -139,7 +139,7 @@ var (
 	}
 	ProtectKernelDefaultsFlag = cli.BoolFlag{
 		Name:        "protect-kernel-defaults",
-		Usage:       "(agent/node) ",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
 		Destination: &AgentConfig.ProtectKernelDefaults,
 	}
 )

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -36,6 +36,7 @@ type Agent struct {
 	Labels                   []string
 	Taints                   []string
 	PrivateRegistry          string
+	ProtectKernelDefaults    bool
 	AgentShared
 }
 
@@ -136,6 +137,11 @@ var (
 		Hidden:      true,
 		Destination: &AgentConfig.DisableSELinux,
 	}
+	ProtectKernelDefaultsFlag = cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) ",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
 )
 
 func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
@@ -192,6 +198,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
 			&FlannelConfFlag,
 			&ExtraKubeletArgs,
 			&ExtraKubeProxyArgs,
+			&ProtectKernelDefaultsFlag,
 			&cli.BoolFlag{
 				Name:        "rootless",
 				Usage:       "(experimental) Run rootless",


### PR DESCRIPTION
Adds the `--protect-kernel-defaults` flag and sets the value to true. This is needed by RKE2 which will set the value to false as part of CIS requirements.