### PR TITLE
Bump k3s-root to v0.6.0-rc3

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -4,7 +4,7 @@ cd $(dirname $0)/..
 
 . ./scripts/version.sh
 
-ROOT_VERSION=v0.6.0-rc1
+ROOT_VERSION=v0.6.0-rc3
 TRAEFIK_VERSION=1.81.0
 CHARTS_DIR=build/static/charts
 


### PR DESCRIPTION
This PR bumps k3s-root to v0.6.0-rc3 in order to support RHEL 7 and 8 operating systems which have VERSION_ID's in /etc/os-release that are of the format X.Y where X is major and Y is minor. This is different than CentOS where the VERSION_ID is simply 7 or 8.

This is work for: https://github.com/rancher/k3s/issues/1812

Signed-off-by: Chris Kim <oats87g@gmail.com>