### PR TITLE
Correctly report and propagate kubeconfig write failures

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -282,8 +282,11 @@ func writeKubeConfig(certs string, config *Config) error {
 	}
 
 	if err = clientaccess.WriteClientKubeConfig(kubeConfig, url, config.ControlConfig.Runtime.ServerCA, config.ControlConfig.Runtime.ClientAdminCert,
-		config.ControlConfig.Runtime.ClientAdminKey); err != nil {
+		config.ControlConfig.Runtime.ClientAdminKey); err == nil {
+		logrus.Infof("Wrote kubeconfig %s", kubeConfig)
+	} else {
 		logrus.Errorf("Failed to generate kubeconfig: %v", err)
+		return err
 	}
 
 	if config.ControlConfig.KubeConfigMode != "" {
@@ -303,7 +306,6 @@ func writeKubeConfig(certs string, config *Config) error {
 		}
 	}
 
-	logrus.Infof("Wrote kubeconfig %s", kubeConfig)
 	if def {
 		logrus.Infof("Run: %s kubectl", filepath.Base(os.Args[0]))
 	}


### PR DESCRIPTION
As seen in issues such as #15 #155 #518 #570 there are situations where
k3s will fail to write the kubeconfig file, but reports that it wrote it
anyway as the success message is printed unconditionally. Also, secondary
actions like setting file mode and creating a symlink are also attempted
even if the file was not created.

This change skips attempting additional actions, and propagates the
failure back upwards.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>