### PR TITLE
add RotateKubeletServerCertificate and set to true

### DIFF
--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -159,6 +159,8 @@ func startKubelet(cfg *config.Agent) error {
 		argsMap["protect-kernel-defaults"] = "true"
 	}
 
+	argsMap["feature-gates"] = addFeatureGate(argsMap["feature-gates"], "RotateKubeletServerCertificate=true")
+
 	args := config.GetArgsList(argsMap, cfg.ExtraKubeletArgs)
 	logrus.Infof("Running kubelet %s", config.ArgString(args))
 

--- a/pkg/daemons/agent/agent.go
+++ b/pkg/daemons/agent/agent.go
@@ -159,8 +159,6 @@ func startKubelet(cfg *config.Agent) error {
 		argsMap["protect-kernel-defaults"] = "true"
 	}
 
-	argsMap["feature-gates"] = addFeatureGate(argsMap["feature-gates"], "RotateKubeletServerCertificate=true")
-
 	args := config.GetArgsList(argsMap, cfg.ExtraKubeletArgs)
 	logrus.Infof("Running kubelet %s", config.ArgString(args))
 

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -141,6 +141,8 @@ func controllerManager(cfg *config.Control, runtime *config.ControlRuntime) erro
 		argsMap["leader-elect"] = "false"
 	}
 
+	argsMap["feature-gates"] = "RotateKubeletServerCertificate=true"
+
 	args := config.GetArgsList(argsMap, cfg.ExtraControllerArgs)
 	logrus.Infof("Running kube-controller-manager %s", config.ArgString(args))
 


### PR DESCRIPTION
Proposed changes
======

For CIS 1.5 requirements in RKE2, we're setting the default behavior of Kubelet to have the RotateKubeletServerCertificate feature gate value set to true here since RKE2 uses this base.

Types of changes
======

Adds the `RotateKubeletServerCertificate` and sets the value to true in the kubelet startup routine.

Verification
======

```sh
ps aux | grep kubelet | grep Rotate
```

Should show the feature-gate enabled.

Linked Issues
======
N/A

Further comments
======
N/A
