### PR TITLE
Feature: add insecure_skip_verify field to registry config template

### DIFF
--- a/pkg/agent/templates/registry.go
+++ b/pkg/agent/templates/registry.go
@@ -25,9 +25,10 @@ type AuthConfig struct {
 
 // TLSConfig contains the CA/Cert/Key used for a registry
 type TLSConfig struct {
-	CAFile   string `toml:"ca_file" yaml:"ca_file"`
-	CertFile string `toml:"cert_file" yaml:"cert_file"`
-	KeyFile  string `toml:"key_file" yaml:"key_file"`
+	CAFile             string `toml:"ca_file" yaml:"ca_file"`
+	CertFile           string `toml:"cert_file" yaml:"cert_file"`
+	KeyFile            string `toml:"key_file" yaml:"key_file"`
+	InsecureSkipVerify bool   `toml:"insecure_skip_verify" yaml:"insecure_skip_verify"`
 }
 
 // Registry is registry settings configured

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -68,6 +68,7 @@ const ContainerdConfigTemplate = `
   {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
   {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
   {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
+  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
 {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
This PR adds the option for `insecure_skip_verify` to the containerd registry template.
It can be found in containerd code over here: https://github.com/containerd/cri/blob/63400c769422618e2998823ec548671cf3e150b1/pkg/config/config.go#L139