### PR TITLE
cli: add --selinux flag to agent/server sub-cmds

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -399,7 +399,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 
 	nodeConfig := &config.Node{
 		Docker:                   envInfo.Docker,
-		DisableSELinux:           envInfo.DisableSELinux,
+		SELinux:                  envInfo.EnableSELinux,
 		ContainerRuntimeEndpoint: envInfo.ContainerRuntimeEndpoint,
 		FlannelBackend:           controlConfig.FlannelBackend,
 	}
@@ -484,7 +484,6 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 	nodeConfig.AgentConfig.DisableKubeProxy = controlConfig.DisableKubeProxy
 	nodeConfig.AgentConfig.Rootless = envInfo.Rootless
 	nodeConfig.AgentConfig.PodManifests = filepath.Join(envInfo.DataDir, DefaultPodManifestPath)
-	nodeConfig.DisableSELinux = envInfo.DisableSELinux
 	nodeConfig.AgentConfig.ProtectKernelDefaults = envInfo.ProtectKernelDefaults
 
 	return nodeConfig, nil

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -233,15 +233,10 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to detect selinux")
 	}
-	if cfg.DisableSELinux {
-		containerdConfig.SELinuxEnabled = false
-		if selEnabled {
-			logrus.Warn("SELinux is enabled for system but has been disabled for containerd by override")
-		}
-	} else {
-		containerdConfig.SELinuxEnabled = selEnabled
-	}
-	if containerdConfig.SELinuxEnabled && !selConfigured {
+	switch {
+	case !cfg.SELinux && selEnabled:
+		logrus.Warn("SELinux is enabled for system but has been disabled for containerd")
+	case cfg.SELinux && !selConfigured:
 		logrus.Warnf("SELinux is enabled for "+version.Program+" but process is not running in context '%s', "+version.Program+"-selinux policy may need to be applied", SELinuxContextType)
 	}
 

--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -235,7 +235,7 @@ func setupContainerdConfig(ctx context.Context, cfg *config.Node) error {
 	}
 	switch {
 	case !cfg.SELinux && selEnabled:
-		logrus.Warn("SELinux is enabled for system but has been disabled for containerd")
+		logrus.Warn("SELinux is enabled on this host, but " + version.Program + " has not been started with --selinux - containerd SELinux support is disabled")
 	case cfg.SELinux && !selConfigured:
 		logrus.Warnf("SELinux is enabled for "+version.Program+" but process is not running in context '%s', "+version.Program+"-selinux policy may need to be applied", SELinuxContextType)
 	}

--- a/pkg/agent/templates/templates.go
+++ b/pkg/agent/templates/templates.go
@@ -10,7 +10,6 @@ import (
 type ContainerdConfig struct {
 	NodeConfig            *config.Node
 	IsRunningInUserNS     bool
-	SELinuxEnabled        bool
 	PrivateRegistryConfig *Registry
 }
 
@@ -21,7 +20,7 @@ const ContainerdConfigTemplate = `
 [plugins.cri]
   stream_server_address = "127.0.0.1"
   stream_server_port = "10010"
-  enable_selinux = {{ .SELinuxEnabled }}
+  enable_selinux = {{ .NodeConfig.SELinux }}
 
 {{- if .IsRunningInUserNS }}
   disable_cgroup = true

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -26,7 +26,7 @@ type Node struct {
 	Docker                   bool
 	ContainerRuntimeEndpoint string
 	NoFlannel                bool
-	DisableSELinux           bool
+	SELinux                  bool
 	FlannelBackend           string
 	FlannelConf              string
 	FlannelConfOverride      bool
@@ -46,6 +46,7 @@ type Containerd struct {
 	Config   string
 	Opt      string
 	Template string
+	SELinux  bool
 }
 
 type Agent struct {


### PR DESCRIPTION
Introduces --selinux flag to affirmatively enable SELinux in containerd.
Deprecates --disable-selinux flag which now defaults to true which means auto-detection of SELinux configuration for containerd is no longer supported.
Specifying both --selinux and --disable-selinux will result in an error message encouraging you to pick a side.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
