### PR TITLE
Fix handling of TLS configuration args

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -187,18 +187,22 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		serverConfig.ControlConfig.Disables["ccm"] = true
 	}
 
-	TLSMinVersion := getArgValueFromList("tls-min-version", cfg.ExtraAPIArgs)
-	serverConfig.ControlConfig.TLSMinVersion, err = kubeapiserverflag.TLSVersion(TLSMinVersion)
+	tlsMinVersionArg := getArgValueFromList("tls-min-version", cfg.ExtraAPIArgs)
+	serverConfig.ControlConfig.TLSMinVersion, err = kubeapiserverflag.TLSVersion(tlsMinVersionArg)
 	if err != nil {
-		return errors.Wrapf(err, "Invalid TLS Version %s: %v", TLSMinVersion, err)
+		return errors.Wrap(err, "Invalid tls-min-version")
 	}
 
 	// TLS config based on mozilla ssl-config generator
 	// https://ssl-config.mozilla.org/#server=golang&version=1.13.6&config=intermediate&guideline=5.4
 	// Need to disable the TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 Cipher for TLS1.2
-	TLSCipherSuites := []string{getArgValueFromList("tls-cipher-suites", cfg.ExtraAPIArgs)}
-	if len(TLSCipherSuites) == 0 || TLSCipherSuites[0] == "" {
-		TLSCipherSuites = []string{
+	tlsCipherSuitesArg := getArgValueFromList("tls-cipher-suites", cfg.ExtraAPIArgs)
+	tlsCipherSuites := strings.Split(tlsCipherSuitesArg, ",")
+	for i := range tlsCipherSuites {
+		tlsCipherSuites[i] = strings.TrimSpace(tlsCipherSuites[i])
+	}
+	if len(tlsCipherSuites) == 0 || tlsCipherSuites[0] == "" {
+		tlsCipherSuites = []string{
 			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -207,9 +211,9 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
 		}
 	}
-	serverConfig.ControlConfig.TLSCipherSuites, err = kubeapiserverflag.TLSCipherSuites(TLSCipherSuites)
+	serverConfig.ControlConfig.TLSCipherSuites, err = kubeapiserverflag.TLSCipherSuites(tlsCipherSuites)
 	if err != nil {
-		return errors.Wrapf(err, "Invalid TLS Cipher Suites %s: %v", TLSCipherSuites, err)
+		return errors.Wrap(err, "Invalid tls-cipher-suites")
 	}
 
 	logrus.Info("Starting "+version.Program+" ", app.App.Version)

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -41,7 +41,7 @@ func Rootless(stateDir string) error {
 			logrus.Fatal(err)
 		}
 		if err := child.Child(*childOpt); err != nil {
-			logrus.Fatal("child died", err)
+			logrus.Fatalf("child died: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Proposed changes
======
Fix handling of `--kube-apiserver-arg` `tls-min-version` and `tls-cipher-suites` options applied to dynamiclistener TLS config.

Types of changes
======
- bugfix

Verification
======
QA to test as per #768

Linked Issues
======
See above

Further comments
======
Also fixed a minor nit in the rootless fatal exit message that I noticed while testing