### PR TITLE
Update helm-controller to v0.6.5 to add helm job toleration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rakelkar/gonetsh v0.0.0-20190719023240-501daadcadf8 // indirect
 	github.com/rancher/dynamiclistener v0.2.0
-	github.com/rancher/helm-controller v0.6.0
+	github.com/rancher/helm-controller v0.6.5
 	github.com/rancher/kine v0.4.0
 	github.com/rancher/remotedialer v0.2.0
 	github.com/rancher/wrangler v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,8 @@ github.com/rancher/dynamiclistener v0.2.0 h1:KucYwJXVVGhZ/NndfMCeQoCafT/VN7kvqSG
 github.com/rancher/dynamiclistener v0.2.0/go.mod h1:fs/dxyNcB3YT6W9fVz4bDGfhmSQS17QQup6BIcGF++s=
 github.com/rancher/flannel v0.11.0-k3s.2 h1:0GVr5ORAIvcri1LYTE8eMQ+NrRbuPeIniPaW51IzLco=
 github.com/rancher/flannel v0.11.0-k3s.2/go.mod h1:Hn4ZV+eq0LhLZP63xZnxdGwXEoRSxs5sxELxu27M3UA=
-github.com/rancher/helm-controller v0.6.0 h1:nFptBZFWpHga65M6bP04BZGLlzeMgezAXdsOwaB8t+4=
-github.com/rancher/helm-controller v0.6.0/go.mod h1:ZylsxIMGNADRPRNW+NiBWhrwwks9vnKLQiCHYWb6Bi0=
+github.com/rancher/helm-controller v0.6.5 h1:gL6R3fbsBFBnrp2Wc36zn0zLQ8q2ckbLpfaN2XkrLVE=
+github.com/rancher/helm-controller v0.6.5/go.mod h1:ZylsxIMGNADRPRNW+NiBWhrwwks9vnKLQiCHYWb6Bi0=
 github.com/rancher/juju-to-pkg-errors v0.0.0-20200701001603-16f3c28b59bd h1:KPnQuOFWU6Jm7dTadhZ9TCVf6Y5NxoSyUjwkbD7En5Q=
 github.com/rancher/juju-to-pkg-errors v0.0.0-20200701001603-16f3c28b59bd/go.mod h1:QYmg8cqWPPfIbpEuhtJbEdWwA6PEKSY016Z6EdfL9+8=
 github.com/rancher/kine v0.4.0 h1:1IhWy3TzjExG8xnj46eyUEWdzqNAD1WrgL4eEBKm6Uc=

--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,5 +1,5 @@
 docker.io/rancher/coredns-coredns:1.6.9
-docker.io/rancher/klipper-helm:v0.2.5
+docker.io/rancher/klipper-helm:v0.2.7
 docker.io/rancher/klipper-lb:v0.1.2
 docker.io/rancher/library-traefik:1.7.19
 docker.io/rancher/local-path-provisioner:v0.0.11

--- a/vendor/github.com/rancher/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
+++ b/vendor/github.com/rancher/helm-controller/pkg/apis/helm.cattle.io/v1/types.go
@@ -24,6 +24,8 @@ type HelmChartSpec struct {
 	Set             map[string]intstr.IntOrString `json:"set,omitempty"`
 	ValuesContent   string                        `json:"valuesContent,omitempty"`
 	HelmVersion     string                        `json:"helmVersion,omitempty"`
+	Bootstrap       bool                          `json:"bootstrap,omitempty"`
+	ChartContent    string                        `json:"chartContent,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/vendor/github.com/rancher/helm-controller/pkg/generated/controllers/helm.cattle.io/factory.go
+++ b/vendor/github.com/rancher/helm-controller/pkg/generated/controllers/helm.cattle.io/factory.go
@@ -52,18 +52,23 @@ func NewFactoryFromConfigOrDie(config *rest.Config) *Factory {
 }
 
 func NewFactoryFromConfig(config *rest.Config) (*Factory, error) {
-	cs, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	informerFactory := informers.NewSharedInformerFactory(cs, 2*time.Hour)
-	return NewFactory(cs, informerFactory), nil
+	return NewFactoryFromConfigWithOptions(config, nil)
 }
 
 func NewFactoryFromConfigWithNamespace(config *rest.Config, namespace string) (*Factory, error) {
-	if namespace == "" {
-		return NewFactoryFromConfig(config)
+	return NewFactoryFromConfigWithOptions(config, &FactoryOptions{
+		Namespace: namespace,
+	})
+}
+
+type FactoryOptions struct {
+	Namespace string
+	Resync    time.Duration
+}
+
+func NewFactoryFromConfigWithOptions(config *rest.Config, opts *FactoryOptions) (*Factory, error) {
+	if opts == nil {
+		opts = &FactoryOptions{}
 	}
 
 	cs, err := clientset.NewForConfig(config)
@@ -71,7 +76,17 @@ func NewFactoryFromConfigWithNamespace(config *rest.Config, namespace string) (*
 		return nil, err
 	}
 
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(cs, 2*time.Hour, informers.WithNamespace(namespace))
+	resync := opts.Resync
+	if resync == 0 {
+		resync = 2 * time.Hour
+	}
+
+	if opts.Namespace == "" {
+		informerFactory := informers.NewSharedInformerFactory(cs, resync)
+		return NewFactory(cs, informerFactory), nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(cs, resync, informers.WithNamespace(opts.Namespace))
 	return NewFactory(cs, informerFactory), nil
 }
 

--- a/vendor/github.com/rancher/helm-controller/pkg/generated/controllers/helm.cattle.io/v1/helmchart.go
+++ b/vendor/github.com/rancher/helm-controller/pkg/generated/controllers/helm.cattle.io/v1/helmchart.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/generic"
+	"github.com/rancher/wrangler/pkg/kv"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -267,6 +268,7 @@ func RegisterHelmChartGeneratingHandler(ctx context.Context, controller HelmChar
 	if opts != nil {
 		statusHandler.opts = *opts
 	}
+	controller.OnChange(ctx, name, statusHandler.Remove)
 	RegisterHelmChartStatusHandler(ctx, controller, condition, name, statusHandler.Handle)
 }
 
@@ -281,7 +283,7 @@ func (a *helmChartStatusHandler) sync(key string, obj *v1.HelmChart) (*v1.HelmCh
 		return obj, nil
 	}
 
-	origStatus := obj.Status
+	origStatus := obj.Status.DeepCopy()
 	obj = obj.DeepCopy()
 	newStatus, err := a.handler(obj, obj.Status)
 	if err != nil {
@@ -289,16 +291,16 @@ func (a *helmChartStatusHandler) sync(key string, obj *v1.HelmChart) (*v1.HelmCh
 		newStatus = *origStatus.DeepCopy()
 	}
 
-	obj.Status = newStatus
 	if a.condition != "" {
 		if errors.IsConflict(err) {
-			a.condition.SetError(obj, "", nil)
+			a.condition.SetError(&newStatus, "", nil)
 		} else {
-			a.condition.SetError(obj, "", err)
+			a.condition.SetError(&newStatus, "", err)
 		}
 	}
-	if !equality.Semantic.DeepEqual(origStatus, obj.Status) {
+	if !equality.Semantic.DeepEqual(origStatus, &newStatus) {
 		var newErr error
+		obj.Status = newStatus
 		obj, newErr = a.client.UpdateStatus(obj)
 		if err == nil {
 			err = newErr
@@ -315,29 +317,28 @@ type helmChartGeneratingHandler struct {
 	name  string
 }
 
+func (a *helmChartGeneratingHandler) Remove(key string, obj *v1.HelmChart) (*v1.HelmChart, error) {
+	if obj != nil {
+		return obj, nil
+	}
+
+	obj = &v1.HelmChart{}
+	obj.Namespace, obj.Name = kv.RSplit(key, "/")
+	obj.SetGroupVersionKind(a.gvk)
+
+	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+		WithOwner(obj).
+		WithSetID(a.name).
+		ApplyObjects()
+}
+
 func (a *helmChartGeneratingHandler) Handle(obj *v1.HelmChart, status v1.HelmChartStatus) (v1.HelmChartStatus, error) {
 	objs, newStatus, err := a.HelmChartGeneratingHandler(obj, status)
 	if err != nil {
 		return newStatus, err
 	}
 
-	apply := a.apply
-
-	if !a.opts.DynamicLookup {
-		apply = apply.WithStrictCaching()
-	}
-
-	if !a.opts.AllowCrossNamespace && !a.opts.AllowClusterScoped {
-		apply = apply.WithSetOwnerReference(true, false).
-			WithDefaultNamespace(obj.GetNamespace()).
-			WithListerNamespace(obj.GetNamespace())
-	}
-
-	if !a.opts.AllowClusterScoped {
-		apply = apply.WithRestrictClusterScoped()
-	}
-
-	return newStatus, apply.
+	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -724,7 +724,7 @@ github.com/rancher/dynamiclistener/factory
 github.com/rancher/dynamiclistener/storage/file
 github.com/rancher/dynamiclistener/storage/kubernetes
 github.com/rancher/dynamiclistener/storage/memory
-# github.com/rancher/helm-controller v0.6.0
+# github.com/rancher/helm-controller v0.6.5
 github.com/rancher/helm-controller/pkg/apis/helm.cattle.io
 github.com/rancher/helm-controller/pkg/apis/helm.cattle.io/v1
 github.com/rancher/helm-controller/pkg/generated/clientset/versioned


### PR DESCRIPTION
Proposed changes
======
Backport for release-1.18:
Update helm-controller to v0.6.5 to add helm job toleration for node.cloudprovider.kubernetes.io/uninitialized

Types of changes
======
- vendor update
- airgap images

Verification
======
1. Add `bootstrap: true` to HelmChart spec
1. Check for new toleration on helm job allowing job to run on uninitialized node

Linked Issues
======
#2140