### PR TITLE
add setup hook capabilities for rke2

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -55,7 +55,7 @@ type Server struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	EncryptSecrets           bool
-	SetupHooks               []func(config.Control) error
+	StartupHooks             []func(config.Control) error
 }
 
 var ServerConfig Server

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -1,6 +1,8 @@
 package cmds
 
 import (
+	"context"
+
 	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/spur/cli"
@@ -55,7 +57,7 @@ type Server struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	EncryptSecrets           bool
-	StartupHooks             []func(config.Control) error
+	StartupHooks             []func(context.Context, config.Control) error
 }
 
 var ServerConfig Server

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"github.com/rancher/k3s/pkg/daemons/config"
 	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/spur/cli"
 	"github.com/rancher/spur/cli/altsrc"
@@ -54,6 +55,7 @@ type Server struct {
 	ClusterInit              bool
 	ClusterReset             bool
 	EncryptSecrets           bool
+	SetupHooks               []func(config.Control) error
 }
 
 var ServerConfig Server

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -193,6 +193,8 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		return errors.Wrap(err, "Invalid tls-min-version")
 	}
 
+	serverConfig.SetupHooks = append(serverConfig.SetupHooks, cfg.SetupHooks...)
+
 	// TLS config based on mozilla ssl-config generator
 	// https://ssl-config.mozilla.org/#server=golang&version=1.13.6&config=intermediate&guideline=5.4
 	// Need to disable the TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 Cipher for TLS1.2

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -193,7 +193,7 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		return errors.Wrap(err, "Invalid tls-min-version")
 	}
 
-	serverConfig.SetupHooks = append(serverConfig.SetupHooks, cfg.SetupHooks...)
+	serverConfig.StartupHooks = append(serverConfig.StartupHooks, cfg.StartupHooks...)
 
 	// TLS config based on mozilla ssl-config generator
 	// https://ssl-config.mozilla.org/#server=golang&version=1.13.6&config=intermediate&guideline=5.4

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -61,7 +61,9 @@ func StartServer(ctx context.Context, config *Config) error {
 	}
 
 	for _, hook := range config.StartupHooks {
-		hook(config.ControlConfig)
+		if err := hook(ctx, config.ControlConfig); err != nil {
+			return errors.Wrap(err, "startup hook")
+		}
 	}
 
 	ip := net2.ParseIP(config.ControlConfig.BindAddress)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,7 +60,7 @@ func StartServer(ctx context.Context, config *Config) error {
 		return errors.Wrap(err, "starting tls server")
 	}
 
-	for _, hook := range config.SetupHooks {
+	for _, hook := range config.StartupHooks {
 		hook(config.ControlConfig)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,6 +60,10 @@ func StartServer(ctx context.Context, config *Config) error {
 		return errors.Wrap(err, "starting tls server")
 	}
 
+	for _, hook := range config.SetupHooks {
+		hook(config.ControlConfig)
+	}
+
 	ip := net2.ParseIP(config.ControlConfig.BindAddress)
 	if ip == nil {
 		hostIP, err := net.ChooseHostInterface()

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/rancher/k3s/pkg/daemons/config"
 )
 
@@ -10,5 +12,5 @@ type Config struct {
 	ControlConfig    config.Control
 	Rootless         bool
 	SupervisorPort   int
-	StartupHooks     []func(config.Control) error
+	StartupHooks     []func(context.Context, config.Control) error
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -10,5 +10,5 @@ type Config struct {
 	ControlConfig    config.Control
 	Rootless         bool
 	SupervisorPort   int
-	SetupHooks       []func(config.Control) error
+	StartupHooks     []func(config.Control) error
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -10,4 +10,5 @@ type Config struct {
 	ControlConfig    config.Control
 	Rootless         bool
 	SupervisorPort   int
+	SetupHooks       []func(config.Control) error
 }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This PR adds the ability to add hooks to be run in bootstrapping in k3s that will ultimately be used during rke2 startup.

Types of changes
======
Adds a slice to a struct field and referenced during k3s start up.

Verification
======
Verification will be had through it's use in this RKE2 pull request. https://github.com/rancher/rke2/pull/199

Linked Issues
======
N/A

Further comments
======
N/A
