### PR TITLE
Update to golang1.15.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.13.15-alpine3.12
+FROM golang:1.15.0-alpine3.12
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM golang:1.13.15-alpine3.12
+FROM golang:1.15.0-alpine3.12
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.13.15-alpine3.12
+FROM golang:1.15.0-alpine3.12
 
 RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2 openssl
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/k3s
 
-go 1.13
+go 1.15
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.7-0.20190926181021-82c7525d98c8

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,8 +66,10 @@ github.com/Microsoft/hcsshim/internal/timeout
 github.com/Microsoft/hcsshim/internal/vmcompute
 github.com/Microsoft/hcsshim/internal/wclayer
 # github.com/NYTimes/gziphandler v1.1.1
+## explicit
 github.com/NYTimes/gziphandler
 # github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
+## explicit
 github.com/Nvveen/Gotty
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
@@ -131,6 +133,7 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.0+incompatible
 github.com/blang/semver
 # github.com/bronze1man/goStrongswanVici v0.0.0-20190828090544-27d02f80ba40
+## explicit
 github.com/bronze1man/goStrongswanVici
 # github.com/canonical/go-dqlite v1.5.1
 github.com/canonical/go-dqlite
@@ -154,10 +157,12 @@ github.com/cilium/ebpf/internal/unix
 # github.com/container-storage-interface/spec v1.2.0
 github.com/container-storage-interface/spec/lib/go/csi
 # github.com/containerd/cgroups v0.0.0-00010101000000-000000000000 => github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601
+## explicit
 github.com/containerd/cgroups
 # github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1 => github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
 github.com/containerd/console
 # github.com/containerd/containerd v1.3.6 => github.com/rancher/containerd v1.3.6-k3s1
+## explicit
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/containers/v1
@@ -286,6 +291,7 @@ github.com/containerd/containerd/sys
 github.com/containerd/containerd/sys/reaper
 github.com/containerd/containerd/version
 # github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 => github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02
+## explicit
 github.com/containerd/continuity
 github.com/containerd/continuity/devices
 github.com/containerd/continuity/driver
@@ -295,6 +301,7 @@ github.com/containerd/continuity/proto
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
 # github.com/containerd/cri v0.0.0-00010101000000-000000000000 => github.com/rancher/cri v1.3.0-k3s.7
+## explicit
 github.com/containerd/cri
 github.com/containerd/cri/pkg/annotations
 github.com/containerd/cri/pkg/api/runtimeoptions/v1
@@ -317,12 +324,16 @@ github.com/containerd/cri/pkg/store/sandbox
 github.com/containerd/cri/pkg/store/snapshot
 github.com/containerd/cri/pkg/util
 # github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
+## explicit
 github.com/containerd/fifo
 # github.com/containerd/go-cni v0.0.0-20190813230227-49fbd9b210f3
+## explicit
 github.com/containerd/go-cni
 # github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda
+## explicit
 github.com/containerd/go-runc
 # github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8
+## explicit
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20 => github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
 github.com/containerd/typeurl
@@ -334,8 +345,10 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v0.8.2
+## explicit
 github.com/containernetworking/plugins/pkg/ns
 # github.com/coreos/flannel v0.11.0 => github.com/rancher/flannel v0.12.0-k3s1
+## explicit
 github.com/coreos/flannel/backend
 github.com/coreos/flannel/backend/extension
 github.com/coreos/flannel/backend/hostgw
@@ -346,12 +359,14 @@ github.com/coreos/flannel/pkg/ip
 github.com/coreos/flannel/subnet
 github.com/coreos/flannel/subnet/kube
 # github.com/coreos/go-iptables v0.4.2
+## explicit
 github.com/coreos/go-iptables/iptables
 # github.com/coreos/go-oidc v2.1.0+incompatible
 github.com/coreos/go-oidc
 # github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+## explicit
 github.com/coreos/go-systemd/activation
 github.com/coreos/go-systemd/daemon
 github.com/coreos/go-systemd/dbus
@@ -373,6 +388,7 @@ github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
 # github.com/docker/docker v1.4.2-0.20191205034852-d163fbba3c82 => github.com/docker/docker v17.12.0-ce-rc1.0.20190219214528-cbe11bdc6da8+incompatible
+## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -411,6 +427,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 github.com/docker/go-events
 # github.com/docker/go-metrics v0.0.1
+## explicit
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
@@ -423,6 +440,7 @@ github.com/dustin/go-humanize
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
+## explicit
 github.com/erikdubbelboer/gspt
 # github.com/euank/go-kmsg-parser v2.0.0+incompatible
 github.com/euank/go-kmsg-parser/kmsgparser
@@ -437,6 +455,7 @@ github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-bindata/go-bindata v3.1.2+incompatible
+## explicit
 github.com/go-bindata/go-bindata
 github.com/go-bindata/go-bindata/go-bindata
 # github.com/go-openapi/analysis v0.19.5
@@ -461,6 +480,7 @@ github.com/go-openapi/swag
 # github.com/go-openapi/validate v0.19.5
 github.com/go-openapi/validate
 # github.com/go-sql-driver/mysql v1.4.1
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
@@ -469,6 +489,7 @@ github.com/godbus/dbus
 # github.com/gofrs/flock v0.7.1
 github.com/gofrs/flock
 # github.com/gogo/googleapis v1.3.0
+## explicit
 github.com/gogo/googleapis/google/rpc
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/gogoproto
@@ -541,8 +562,10 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
+## explicit
 github.com/google/tcpproxy
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.3.1
 github.com/googleapis/gnostic/OpenAPIv2
@@ -581,8 +604,10 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/mux v1.7.4
+## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.1
+## explicit
 github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache
@@ -617,9 +642,11 @@ github.com/karrick/godirwalk
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kubernetes-sigs/cri-tools v0.0.0-00010101000000-000000000000 => github.com/rancher/cri-tools v1.18.0-k3s1
+## explicit
 github.com/kubernetes-sigs/cri-tools/cmd/crictl
 github.com/kubernetes-sigs/cri-tools/pkg/version
 # github.com/lib/pq v1.1.1
+## explicit
 github.com/lib/pq
 github.com/lib/pq/oid
 github.com/lib/pq/scram
@@ -634,6 +661,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/mattn/go-shellwords v1.0.5
 github.com/mattn/go-shellwords
 # github.com/mattn/go-sqlite3 v1.13.0
+## explicit
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
@@ -660,6 +688,7 @@ github.com/munnerz/goautoneg
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 github.com/mxk/go-flowrate/flowrate
 # github.com/natefinch/lumberjack v2.0.0+incompatible
+## explicit
 github.com/natefinch/lumberjack
 # github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/go-digest
@@ -668,6 +697,7 @@ github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.0-rc10
+## explicit
 github.com/opencontainers/runc
 github.com/opencontainers/runc/contrib/cmd/recvtty
 github.com/opencontainers/runc/libcontainer
@@ -697,12 +727,14 @@ github.com/opencontainers/runc/types
 # github.com/opencontainers/runtime-spec v1.0.0 => github.com/opencontainers/runtime-spec v0.0.0-20180911193056-5684b8af48c1
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.5.3-0.20200613095409-bb88c45a3863
+## explicit
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
 github.com/pquerna/cachecontrol
@@ -727,6 +759,7 @@ github.com/prometheus/procfs/xfs
 github.com/rakelkar/gonetsh/netroute
 github.com/rakelkar/gonetsh/netsh
 # github.com/rancher/dynamiclistener v0.2.1
+## explicit
 github.com/rancher/dynamiclistener
 github.com/rancher/dynamiclistener/cert
 github.com/rancher/dynamiclistener/factory
@@ -737,6 +770,7 @@ github.com/rancher/dynamiclistener/storage/memory
 github.com/rancher/go-powershell/backend
 github.com/rancher/go-powershell/utils
 # github.com/rancher/helm-controller v0.7.2
+## explicit
 github.com/rancher/helm-controller/pkg/apis/helm.cattle.io
 github.com/rancher/helm-controller/pkg/apis/helm.cattle.io/v1
 github.com/rancher/helm-controller/pkg/generated/clientset/versioned
@@ -751,6 +785,7 @@ github.com/rancher/helm-controller/pkg/generated/informers/externalversions/inte
 github.com/rancher/helm-controller/pkg/generated/listers/helm.cattle.io/v1
 github.com/rancher/helm-controller/pkg/helm
 # github.com/rancher/kine v0.4.0
+## explicit
 github.com/rancher/kine/pkg/broadcaster
 github.com/rancher/kine/pkg/client
 github.com/rancher/kine/pkg/drivers/dqlite
@@ -764,13 +799,16 @@ github.com/rancher/kine/pkg/logstructured/sqllog
 github.com/rancher/kine/pkg/server
 github.com/rancher/kine/pkg/tls
 # github.com/rancher/remotedialer v0.2.0
+## explicit
 github.com/rancher/remotedialer
 # github.com/rancher/spur v0.0.0-20200617165101-8702c8e4ce7a
+## explicit
 github.com/rancher/spur/cli
 github.com/rancher/spur/cli/altsrc
 github.com/rancher/spur/flag
 github.com/rancher/spur/generic
 # github.com/rancher/wrangler v0.6.1
+## explicit
 github.com/rancher/wrangler/pkg/apply
 github.com/rancher/wrangler/pkg/apply/injectors
 github.com/rancher/wrangler/pkg/cleanup
@@ -799,6 +837,7 @@ github.com/rancher/wrangler/pkg/signals
 github.com/rancher/wrangler/pkg/slice
 github.com/rancher/wrangler/pkg/start
 # github.com/rancher/wrangler-api v0.6.0
+## explicit
 github.com/rancher/wrangler-api/pkg/generated/controllers/apps
 github.com/rancher/wrangler-api/pkg/generated/controllers/apps/v1
 github.com/rancher/wrangler-api/pkg/generated/controllers/batch
@@ -810,6 +849,7 @@ github.com/rancher/wrangler-api/pkg/generated/controllers/rbac/v1
 # github.com/robfig/cron v1.1.0
 github.com/robfig/cron
 # github.com/rootless-containers/rootlesskit v0.10.0
+## explicit
 github.com/rootless-containers/rootlesskit/pkg/api
 github.com/rootless-containers/rootlesskit/pkg/api/client
 github.com/rootless-containers/rootlesskit/pkg/api/router
@@ -849,6 +889,7 @@ github.com/seccomp/libseccomp-golang
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/soheilhy/cmux v0.1.4
 github.com/soheilhy/cmux
@@ -858,14 +899,17 @@ github.com/spf13/afero/mem
 # github.com/spf13/cobra v0.0.5
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
 # github.com/tchap/go-patricia v2.3.0+incompatible
+## explicit
 github.com/tchap/go-patricia/patricia
 # github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8
 github.com/tmc/grpc-websocket-proxy/wsproxy
 # github.com/urfave/cli v1.22.2
+## explicit
 github.com/urfave/cli
 # github.com/urfave/cli/v2 v2.2.0
 github.com/urfave/cli/v2
@@ -906,6 +950,7 @@ github.com/xiang90/probing
 # go.etcd.io/bbolt v1.3.3
 go.etcd.io/bbolt
 # go.etcd.io/etcd v0.5.0-alpha.5.0.20200520232829-54ba9589114f
+## explicit
 go.etcd.io/etcd/auth
 go.etcd.io/etcd/auth/authpb
 go.etcd.io/etcd/client
@@ -1019,6 +1064,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
@@ -1038,6 +1084,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20200506145744-7e3656a0809f
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -1067,6 +1114,7 @@ golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
@@ -1165,6 +1213,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.26.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -1222,8 +1271,10 @@ gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/warnings.v0 v0.1.1
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.5 => github.com/rancher/kubernetes/staging/src/k8s.io/api v1.18.8-k3s1
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1308,6 +1359,7 @@ k8s.io/apiextensions-apiserver/pkg/registry/customresource
 k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor
 k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition
 # k8s.io/apimachinery v0.18.5 => github.com/rancher/kubernetes/staging/src/k8s.io/apimachinery v1.18.8-k3s1
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -1370,6 +1422,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.0.0 => github.com/rancher/kubernetes/staging/src/k8s.io/apiserver v1.18.8-k3s1
+## explicit
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer
@@ -1513,6 +1566,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible => github.com/rancher/kubernetes/staging/src/k8s.io/client-go v1.18.8-k3s1
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached
 k8s.io/client-go/discovery/cached/disk
@@ -1747,6 +1801,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => github.com/rancher/kubernetes/staging/src/k8s.io/cloud-provider v1.18.8-k3s1
+## explicit
 k8s.io/cloud-provider
 k8s.io/cloud-provider/api
 k8s.io/cloud-provider/node/helpers
@@ -1776,6 +1831,7 @@ k8s.io/code-generator/cmd/lister-gen/generators
 k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
 # k8s.io/component-base v0.0.0 => github.com/rancher/kubernetes/staging/src/k8s.io/component-base v1.18.8-k3s1
+## explicit
 k8s.io/component-base/cli/flag
 k8s.io/component-base/cli/globalflag
 k8s.io/component-base/codec
@@ -1794,6 +1850,7 @@ k8s.io/component-base/metrics/testutil
 k8s.io/component-base/version
 k8s.io/component-base/version/verflag
 # k8s.io/cri-api v0.0.0 => github.com/rancher/kubernetes/staging/src/k8s.io/cri-api v1.18.8-k3s1
+## explicit
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 # k8s.io/csi-translation-lib v0.0.0 => github.com/rancher/kubernetes/staging/src/k8s.io/csi-translation-lib v1.18.8-k3s1
@@ -1810,6 +1867,7 @@ k8s.io/gengo/types
 # k8s.io/heapster v1.2.0-beta.1
 k8s.io/heapster/metrics/api/v1/types
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-aggregator v0.18.0 => github.com/rancher/kubernetes/staging/src/k8s.io/kube-aggregator v1.18.8-k3s1
 k8s.io/kube-aggregator/pkg/apis/apiregistration
@@ -1937,6 +1995,7 @@ k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1
 k8s.io/kubelet/pkg/apis/pluginregistration/v1
 # k8s.io/kubernetes v1.18.0 => github.com/rancher/kubernetes v1.18.8-k3s1
+## explicit
 k8s.io/kubernetes/cmd/cloud-controller-manager/app
 k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config
 k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config/scheme
@@ -2775,6 +2834,63 @@ sigs.k8s.io/structured-merge-diff/v3/schema
 sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 vbom.ml/util/sortorder
+# github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.7-0.20190926181021-82c7525d98c8
+# github.com/benmoss/go-powershell => github.com/rancher/go-powershell v0.0.0-20200701184732-233247d45373
+# github.com/containerd/btrfs => github.com/containerd/btrfs v0.0.0-20181101203652-af5082808c83
+# github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601
+# github.com/containerd/console => github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
+# github.com/containerd/containerd => github.com/rancher/containerd v1.3.6-k3s1
+# github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02
+# github.com/containerd/cri => github.com/rancher/cri v1.3.0-k3s.7
+# github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
+# github.com/containerd/typeurl => github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
+# github.com/coreos/flannel => github.com/rancher/flannel v0.12.0-k3s1
+# github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+# github.com/docker/distribution => github.com/docker/distribution v0.0.0-20190205005809-0d3efadf0154
+# github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20190219214528-cbe11bdc6da8+incompatible
+# github.com/docker/libnetwork => github.com/docker/libnetwork v0.8.0-dev.2.0.20190624125649-f0e46a78ea34
+# github.com/go-critic/go-critic => github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540
+# github.com/golangci/errcheck => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
+# github.com/golangci/go-tools => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
+# github.com/golangci/gofmt => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
+# github.com/golangci/gosec => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
+# github.com/golangci/ineffassign => github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc
+# github.com/golangci/lint-1 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
+# github.com/juju/errors => github.com/rancher/nocode v0.0.0-20200630202308-cb097102c09f
+# github.com/kubernetes-sigs/cri-tools => github.com/rancher/cri-tools v1.18.0-k3s1
+# github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
+# github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v0.0.0-20180911193056-5684b8af48c1
+# github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+# github.com/prometheus/client_model => github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
+# github.com/prometheus/common => github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
+# github.com/prometheus/procfs => github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a
+# k8s.io/api => github.com/rancher/kubernetes/staging/src/k8s.io/api v1.18.8-k3s1
+# k8s.io/apiextensions-apiserver => github.com/rancher/kubernetes/staging/src/k8s.io/apiextensions-apiserver v1.18.8-k3s1
+# k8s.io/apimachinery => github.com/rancher/kubernetes/staging/src/k8s.io/apimachinery v1.18.8-k3s1
+# k8s.io/apiserver => github.com/rancher/kubernetes/staging/src/k8s.io/apiserver v1.18.8-k3s1
+# k8s.io/cli-runtime => github.com/rancher/kubernetes/staging/src/k8s.io/cli-runtime v1.18.8-k3s1
+# k8s.io/client-go => github.com/rancher/kubernetes/staging/src/k8s.io/client-go v1.18.8-k3s1
+# k8s.io/cloud-provider => github.com/rancher/kubernetes/staging/src/k8s.io/cloud-provider v1.18.8-k3s1
+# k8s.io/cluster-bootstrap => github.com/rancher/kubernetes/staging/src/k8s.io/cluster-bootstrap v1.18.8-k3s1
+# k8s.io/code-generator => github.com/rancher/kubernetes/staging/src/k8s.io/code-generator v1.18.8-k3s1
+# k8s.io/component-base => github.com/rancher/kubernetes/staging/src/k8s.io/component-base v1.18.8-k3s1
+# k8s.io/cri-api => github.com/rancher/kubernetes/staging/src/k8s.io/cri-api v1.18.8-k3s1
+# k8s.io/csi-translation-lib => github.com/rancher/kubernetes/staging/src/k8s.io/csi-translation-lib v1.18.8-k3s1
+# k8s.io/kube-aggregator => github.com/rancher/kubernetes/staging/src/k8s.io/kube-aggregator v1.18.8-k3s1
+# k8s.io/kube-controller-manager => github.com/rancher/kubernetes/staging/src/k8s.io/kube-controller-manager v1.18.8-k3s1
+# k8s.io/kube-proxy => github.com/rancher/kubernetes/staging/src/k8s.io/kube-proxy v1.18.8-k3s1
+# k8s.io/kube-scheduler => github.com/rancher/kubernetes/staging/src/k8s.io/kube-scheduler v1.18.8-k3s1
+# k8s.io/kubectl => github.com/rancher/kubernetes/staging/src/k8s.io/kubectl v1.18.8-k3s1
+# k8s.io/kubelet => github.com/rancher/kubernetes/staging/src/k8s.io/kubelet v1.18.8-k3s1
+# k8s.io/kubernetes => github.com/rancher/kubernetes v1.18.8-k3s1
+# k8s.io/legacy-cloud-providers => github.com/rancher/kubernetes/staging/src/k8s.io/legacy-cloud-providers v1.18.8-k3s1
+# k8s.io/metrics => github.com/rancher/kubernetes/staging/src/k8s.io/metrics v1.18.8-k3s1
+# k8s.io/node-api => github.com/rancher/kubernetes/staging/src/k8s.io/node-api v1.18.8-k3s1
+# k8s.io/sample-apiserver => github.com/rancher/kubernetes/staging/src/k8s.io/sample-apiserver v1.18.8-k3s1
+# k8s.io/sample-cli-plugin => github.com/rancher/kubernetes/staging/src/k8s.io/sample-cli-plugin v1.18.8-k3s1
+# k8s.io/sample-controller => github.com/rancher/kubernetes/staging/src/k8s.io/sample-controller v1.18.8-k3s1
+# mvdan.cc/unparam => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Update the golang compiler to 1.15.0 (go1.14 is being skipped by the k/k community)

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Verification
======
```
$ ./dist/artifacts/k3s --version
k3s version v1.18.8+k3s-d03351df-dirty (d03351df)
$ ./dist/artifacts/k3s server &
[1] 2263
$ INFO[0000] Preparing data dir /var/lib/rancher/k3s/data/e3127e60c3b3e0ecec03f03adc71d616fa04bc52d0db70b2cdaec50a2869c6b2
INFO[2020-08-26T07:35:59.596796295Z] Starting k3s v1.18.8+k3s-d03351df-dirty (d03351df)
INFO[2020-08-26T07:35:59.630763829Z] Kine listening on unix://kine.sock
INFO[2020-08-26T07:35:59.643631928Z] certificate CN=system:admin,O=system:masters signed by CN=k3s-client-ca@1598427359: notBefore=2020-08-26 07:35:59 +0000 UTC notAfter=2021-08-26 07:35:59 +0000 UTC
INFO[2020-08-26T07:35:59.644215689Z] certificate CN=system:kube-controller-manager signed by CN=k3s-client-ca@1598427359: notBefore=2020-08-26 07:35:59 +0000 UTCnotAfter=2021-08-26 07:35:59 +0000 UTC
INFO[2020-08-26T07:35:59.644695877Z] certificate CN=system:kube-scheduler signed by CN=k3s-client-ca@1598427359: notBefore=2020-08-26 07:35:59 +0000 UTC notAfter=2021-08-26 07:35:59 +0000 UTC
...

$
$ ./dist/artifacts/k3s kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.8+k3s-d03351df-dirty", GitCommit:"d03351dfe2f39dea2916a33bdcea0c7feff82a4c", GitTreeState:"dirty", BuildDate:"2020-08-26T07:27:52Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.8+k3s-d03351df-dirty", GitCommit:"d03351dfe2f39dea2916a33bdcea0c7feff82a4c", GitTreeState:"dirty", BuildDate:"2020-08-26T07:27:52Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
$
$ ./dist/artifacts/k3s kubectl get all -A
NAMESPACE     NAME                                          READY   STATUS      RESTARTS   AGE
kube-system   pod/metrics-server-7566d596c8-4fnjr           1/1     Running     0          74s
kube-system   pod/local-path-provisioner-5597b6889b-fq2v7   1/1     Running     0          74s
kube-system   pod/coredns-6c7f74c576-cw2rt                  1/1     Running     0          74s
kube-system   pod/helm-install-traefik-4845h                0/1     Completed   0          75s
kube-system   pod/svclb-traefik-bkxzl                       2/2     Running     0          56s
kube-system   pod/traefik-758cd5fc85-95qwj                  1/1     Running     0          56s

NAMESPACE     NAME                         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
default       service/kubernetes           ClusterIP      10.43.0.1       <none>        443/TCP                      89s
kube-system   service/kube-dns             ClusterIP      10.43.0.10      <none>        53/UDP,53/TCP,9153/TCP       86s
kube-system   service/metrics-server       ClusterIP      10.43.202.236   <none>        443/TCP                      86s
kube-system   service/traefik-prometheus   ClusterIP      10.43.199.126   <none>        9100/TCP                     56s
kube-system   service/traefik              LoadBalancer   10.43.183.138   172.17.0.70   80:32165/TCP,443:31070/TCP   56s

NAMESPACE     NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
kube-system   daemonset.apps/svclb-traefik   1         1         1       1            1           <none>          56s

NAMESPACE     NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
kube-system   deployment.apps/metrics-server           1/1     1            1           86s
kube-system   deployment.apps/local-path-provisioner   1/1     1            1           86s
kube-system   deployment.apps/coredns                  1/1     1            1           86s
kube-system   deployment.apps/traefik                  1/1     1            1           56s

NAMESPACE     NAME                                                DESIRED   CURRENT   READY   AGE
kube-system   replicaset.apps/metrics-server-7566d596c8           1         1         1       74s
kube-system   replicaset.apps/local-path-provisioner-5597b6889b   1         1         1       74s
kube-system   replicaset.apps/coredns-6c7f74c576                  1         1         1       74s
kube-system   replicaset.apps/traefik-758cd5fc85                  1         1         1       56s

NAMESPACE     NAME                             COMPLETIONS   DURATION   AGE
kube-system   job.batch/helm-install-traefik   1/1           20s        85s
$

```
Linked Issues
======
#2086

Further comments
======
[go1.15 is awesome, it reduces binary sizes ~10% compared to go1.13.](https://tip.golang.org/doc/go1.15#compiler)

- Build with go1.15.0

```
$ tree -alph ./dist/
./dist/
└── [drwxr-xr-x 4.0K]  artifacts
    ├── [-rwxr-xr-x  73M]  k3s
    ├── [-rw------- 351M]  k3s-airgap-images-amd64.tar
    └── [-rw-r--r--  272]  k3s-images.txt

1 directory, 3 files
$ tree -alph ./build/
./build/
├── [drwxr-xr-x 4.0K]  data
├── [drwxr-xr-x 4.0K]  out
│   └── [-rw-r--r--  46M]  data.tar.gz
└── [drwxr-xr-x 4.0K]  static
    └── [drwxr-xr-x 4.0K]  charts
        └── [-rw-r--r--  27K]  traefik-1.81.0.tgz

4 directories, 2 files
$
```

- Build with go1.13.4

```
$ tree -alph ./dist/
./dist/
└── [drwxr-xr-x 4.0K]  artifacts
    ├── [-rwxr-xr-x  81M]  k3s
    ├── [-rw------- 351M]  k3s-airgap-images-amd64.tar
    └── [-rw-r--r--  272]  k3s-images.txt

1 directory, 3 files
$ tree -alph ./build/
./build/
├── [drwxr-xr-x 4.0K]  data
├── [drwxr-xr-x 4.0K]  out
│   └── [-rw-r--r--  50M]  data.tar.gz
└── [drwxr-xr-x 4.0K]  static
    └── [drwxr-xr-x 4.0K]  charts
        └── [-rw-r--r--  27K]  traefik-1.81.0.tgz

4 directories, 2 files
$ 
```
