### PR TITLE
2120: fix issue with umount arg list too long on uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -554,7 +554,7 @@ do_unmount() {
     MOUNTS=$(printf $MOUNTS | grep "^$1" | sort -r)
     if [ -n "${MOUNTS}" ]; then
         set -x
-        umount ${MOUNTS}
+        xargs -n 1 umount <<< ${MOUNTS}
     else
         set -x
     fi

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -554,7 +554,7 @@ do_unmount() {
     MOUNTS=$(printf $MOUNTS | grep "^$1" | sort -r)
     if [ -n "${MOUNTS}" ]; then
         set -x
-        umount ${MOUNTS}
+        xargs -n 1 umount <<< ${MOUNTS}
     else
         set -x
     fi


### PR DESCRIPTION
Signed-off-by: Patrick Force <patrickforce@gmail.com>

Proposed changes
======
* Fixing issue where the install.sh script umount calls end up with an arg list that's too long. Just split up the calls.

Types of changes
======
* Bugfix

Verification
======
Testing the `do_unmount` method continues to operate as expected in all cases. The updated function(s) were tested in isolation to make sure they still work correctly.

Linked Issues
======
* https://github.com/rancher/k3s/issues/2120
