### PR TITLE
Typo fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you're interested in contributing documentation, please note the following:
 
 ## Developer Certificate Of Origin ##
 
-To contribute to this project, you must agree to the Developer Certificate of Origin (DCO) for each commit you make. The DCO is a simple statement that you, as a contributor, have the legal rite to make the contribution.
+To contribute to this project, you must agree to the Developer Certificate of Origin (DCO) for each commit you make. The DCO is a simple statement that you, as a contributor, have the legal right to make the contribution.
 
 See the [DCO](DCO) file for the full text of what you must agree to.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are two major ways that K3s is lighter weight than upstream Kubernetes:
 1. The memory footprint to run it is smaller
 2. The binary, which contains all the non-containerized components needed to run a cluster, is smaller
 
-The memory footprint is reduced primarily by running many components inside of single process. This eliminates significant overhead that would otherwise be duplicated for each component.
+The memory footprint is reduced primarily by running many components inside of a single process. This eliminates significant overhead that would otherwise be duplicated for each component.
 
 The binary is smaller by removing third-party storage drivers and cloud providers, which is explained in more detail below.
 


### PR DESCRIPTION
Proposed changes
======

Fix missing article in
> The memory footprint is reduced primarily by running many components inside of `a` single process.

And typo in 
> The DCO is a simple statement that you, as a contributor, have the legal ~rite~ `right` to make the contribution.

Types of changes
======

Typo fixes