### PR TITLE
Import containerd images with all platforms

### DIFF
--- a/pkg/agent/containerd/containerd.go
+++ b/pkg/agent/containerd/containerd.go
@@ -202,7 +202,7 @@ func preloadImages(ctx context.Context, cfg *config.Node) error {
 				continue
 			}
 		}
-		_, err = client.Import(ctxContainerD, imageReader)
+		_, err = client.Import(ctxContainerD, imageReader, containerd.WithAllPlatforms(true))
 		file.Close()
 		if err != nil {
 			logrus.Errorf("Unable to import %s: %v", filePath, err)


### PR DESCRIPTION
#### Proposed Changes ####

Set WithAllPlatforms option on containerd image import.

#### Types of Changes ####

* airgap image load

#### Verification ####

1. Perform airgap install on arm64
1. Run `k3s ctr images check`; verify all image layers present
1. Run `k3s kubectl get pods -A`; verify all pods running or completed

#### Linked Issues ####

Related to #1285

#### Further Comments ####

Some of the images contain configs that indicate they are amd64 despite actually being arm64. This causes the containerd import process to skip their layers since it filters out mismatched architectures by default. Setting the option to import layers for all platforms allows us to use these images anyways, until the upstreams are fixed.
