### PR TITLE
All arguments should be of the form --k=v so that bool flags will work

### DIFF
--- a/pkg/configfilearg/parser.go
+++ b/pkg/configfilearg/parser.go
@@ -104,15 +104,11 @@ func readConfigFile(file string) (result []string, _ error) {
 
 		if slice, ok := v.([]interface{}); ok {
 			for _, v := range slice {
-				result = append(result, prefix+k, convert.ToString(v))
-				result = append(result)
+				result = append(result, prefix+k+"="+convert.ToString(v))
 			}
 		} else {
 			str := convert.ToString(v)
-			result = append(result, prefix+k)
-			if str != "" {
-				result = append(result, str)
-			}
+			result = append(result, prefix+k+"="+str)
 		}
 	}
 

--- a/pkg/configfilearg/parser_test.go
+++ b/pkg/configfilearg/parser_test.go
@@ -150,14 +150,15 @@ func TestConfigFile(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	testDataOutput := []string{
-		"--foo-bar", "baz",
-		"--a-slice", "1",
-		"--a-slice", "2",
-		"--a-slice", "",
-		"--a-slice", "three",
-		"--isempty",
-		"-c", "b",
-		"--islast", "true",
+		"--foo-bar=baz",
+		"--a-slice=1",
+		"--a-slice=2",
+		"--a-slice=",
+		"--a-slice=three",
+		"--isempty=",
+		"-c=b",
+		"--isfalse=false",
+		"--islast=true",
 	}
 
 	defParser := Parser{

--- a/pkg/configfilearg/testdata/data.yaml
+++ b/pkg/configfilearg/testdata/data.yaml
@@ -6,4 +6,5 @@ a-slice:
 - three
 isempty:
 c: b
+isfalse: false
 islast: true


### PR DESCRIPTION
Previously a bool flag would be rendered as `--flag false` for `flag: false`
which is invalid and results in the opposite of what you'd expect.