### PR TITLE
Add network dependency to installed service file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -644,6 +644,7 @@ create_systemd_service_file() {
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 Wants=network-online.target
+After=network-online.target
 
 [Install]
 WantedBy=multi-user.target

--- a/package/rpm/install.sh
+++ b/package/rpm/install.sh
@@ -649,6 +649,7 @@ create_systemd_service_file() {
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 Wants=network-online.target
+After=network-online.target
 Conflicts=${conflicts}
 
 [Install]


### PR DESCRIPTION
Proposed changes
======
Adds the line `After=network-online.target` to the k3s systemd service
file. This applies the fix mentioned in
[this GH comment](https://github.com/rancher/k3s/issues/1626#issuecomment-642253812)
which I can confirm makes k3s networking survive reboot in Raspbian
Buster.

Types of changes
======
- Bugfix

Verification
======
Testing steps:
1. You can confirm that networking doesn't adequately restore before applying this fix by using a Raspi 3 running a recent, clean install of Raspbian Buster and installing k3s on it using all the defaults. If you reboot this Pi set up this way, pods such as a deployed Dashboard enter the CrashLoopBackoff state.
2. After applying this fix [you can even edit the service file in-place to add this line] rebooting the pi now cleanly comes up with networking working.

Linked Issues
======
https://github.com/rancher/k3s/issues/1626#issuecomment-642253812

Further comments
======
Before I submitted this as a "fix" I wanted to understand what was going on and make sure
that this was the correct sort of way to solve this problem. [It appears, in some docs I found](https://www.digitalocean.com/community/tutorials/understanding-systemd-units-and-unit-files)
that this is a recommended and usual way of specifying that we need the
target to be _completed_ before starting k3s. Using just the `Wants=`
directive doesn't work for this task, you have to add both directives
at once to do this. Quote:

> `Wants=`: This directive is similar to `Requires=`, but less strict.
> `Systemd` will attempt to start any units listed here when this unit
> is activated. If these units are not found or fail to start, the
> current unit will continue to function. This is the recommended way to
> configure most dependency relationships. **Again, this implies a
> parallel activation unless modified by other directives**

> [...]

> `After=`: The units listed in this directive will be started before
> starting the current unit. This does not imply a dependency
> relationship and **one must be established through the above
> directives if this is required.**

- _(Emphasis mine)_

So I believe that you need both the `Wants=` and `After=` at the
same time to have networking definitely come up prior to k3s
being started. 

Signed-off-by: Matthew Clive <arcticlight@arcticlight.me>