### PR TITLE
server: set master label before controllers

### DIFF
--- a/scripts/binary_size_check.sh
+++ b/scripts/binary_size_check.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
-
+#!/bin/bash
 set -e
 
-if [ "${DEBUG}" = 1 ]; then
+cd $(dirname $0)/..
+
+if [ -n "${DEBUG}" ]; then
     set -x
 fi
 


### PR DESCRIPTION
Set the master label and DNS config before applying controllers.

Also, fix the binary size check in CI.
