### PR TITLE
Add support for disabling all staged content at build time

### DIFF
--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -44,6 +44,7 @@ func main() {
 		NoMetadata: true,
 		Prefix:     "manifests/",
 		Output:     "pkg/deploy/zz_generated_bindata.go",
+		Tags:       "!no_stage",
 	}
 	if err := bindata.Translate(bc); err != nil {
 		logrus.Fatal(err)
@@ -60,6 +61,7 @@ func main() {
 		NoMetadata: true,
 		Prefix:     "build/static/",
 		Output:     "pkg/static/zz_generated_bindata.go",
+		Tags:       "!no_stage",
 	}
 	if err := bindata.Translate(bc); err != nil {
 		logrus.Fatal(err)

--- a/pkg/deploy/nostage.go
+++ b/pkg/deploy/nostage.go
@@ -1,0 +1,7 @@
+// +build no_stage
+
+package deploy
+
+func Stage(dataDir string, templateVars map[string]string, skips map[string]bool) error {
+	return nil
+}

--- a/pkg/deploy/stage.go
+++ b/pkg/deploy/stage.go
@@ -1,3 +1,5 @@
+// +build !no_stage
+
 package deploy
 
 import (

--- a/pkg/deploy/zz_generated_bindata.go
+++ b/pkg/deploy/zz_generated_bindata.go
@@ -12,6 +12,8 @@
 // manifests/metrics-server/resource-reader.yaml
 // manifests/rolebindings.yaml
 // manifests/traefik.yaml
+// +build !no_stage
+
 package deploy
 
 import (

--- a/pkg/static/nostage.go
+++ b/pkg/static/nostage.go
@@ -1,0 +1,7 @@
+// +build no_stage
+
+package static
+
+func Stage(dataDir string) error {
+	return nil
+}

--- a/pkg/static/stage.go
+++ b/pkg/static/stage.go
@@ -1,3 +1,5 @@
+// +build !no_stage
+
 package static
 
 import (

--- a/pkg/static/zz_generated_bindata.go
+++ b/pkg/static/zz_generated_bindata.go
@@ -1,6 +1,8 @@
 // Code generated for package static by go-bindata DO NOT EDIT. (@generated)
 // sources:
 // build/static/charts/traefik-1.81.0.tgz
+// +build !no_stage
+
 package static
 
 import (


### PR DESCRIPTION
#### Proposed Changes ####

Put the k3s manifests and static content inside a build tag so that we can disable them when compiling for rke2

#### Types of Changes ####

* build tag

#### Verification ####

1. Add no_stage to TAGS in scripts/build
1. Build k3s
1. Start k3s on clean system
1. Note that /var/lib/rancher/k3s/server/manifests and /var/lib/rancher/k3s/server/static are not created

#### Linked Issues ####

Related to https://github.com/rancher/rke2/issues/232

#### Further Comments ####

This breaks k3s unless the user provides their own copy of all the core manifests (role bindings, coredns, etc), but this is the desired behavior for RKE2 which provides its own content.