### PR TITLE
Add error logger to http server

### DIFF
--- a/pkg/clientaccess/clientaccess.go
+++ b/pkg/clientaccess/clientaccess.go
@@ -236,9 +236,14 @@ func GetCACerts(u url.URL) ([]byte, error) {
 	u.Path = "/cacerts"
 	url := u.String()
 
+	_, err := get(url, http.DefaultClient, "", "")
+	if err == nil {
+		return nil, nil
+	}
+
 	cacerts, err := get(url, insecureClient, "", "")
-	if err != nil || cacerts == nil {
-		return nil, errors.Wrapf(err, "failed to get CA certs at url %s", url)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get CA certs at %s", url)
 	}
 
 	_, err = get(url, GetHTTPClient(cacerts), "", "")

--- a/pkg/clientaccess/clientaccess.go
+++ b/pkg/clientaccess/clientaccess.go
@@ -236,14 +236,9 @@ func GetCACerts(u url.URL) ([]byte, error) {
 	u.Path = "/cacerts"
 	url := u.String()
 
-	_, err := get(url, http.DefaultClient, "", "")
-	if err == nil {
-		return nil, nil
-	}
-
 	cacerts, err := get(url, insecureClient, "", "")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get CA certs at %s", url)
+	if err != nil || cacerts == nil {
+		return nil, errors.Wrapf(err, "failed to get CA certs at url %s", url)
 	}
 
 	_, err = get(url, GetHTTPClient(cacerts), "", "")

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"log"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -61,6 +62,8 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 
 	server := http.Server{
 		Handler: handler,
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "Cluster-Http-Server", log.LstdFlags),
+
 	}
 
 	go func() {

--- a/pkg/cluster/https.go
+++ b/pkg/cluster/https.go
@@ -61,9 +61,8 @@ func (c *Cluster) initClusterAndHTTPS(ctx context.Context) error {
 	}
 
 	server := http.Server{
-		Handler: handler,
-		ErrorLog: log.New(logrus.StandardLogger().Writer(), "Cluster-Http-Server", log.LstdFlags),
-
+		Handler:  handler,
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "Cluster-Http-Server ", log.LstdFlags),
 	}
 
 	go func() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

- ##### Problem : #####
 GetCACerts function initial check was to try and get the Certificates with https.DefaultClient, which resulted in tls handshake error when http request is sent in client.Do(req) https://github.com/rancher/k3s/blob/7f32e50bf795af0dff5ce9b14968d9b4ca7fbe51/pkg/clientaccess/clientaccess.go#L261
- ##### Proposed fix #####  
Remove the initial check that's causing bad certificates error and validate if the certificates exist using insecureClient 
#### Types of Changes ####

Bugfix 
#### Verification ####

run k3s/rke2 multinode cluster and check the server logs, tls handshake errors presented in the issue below will not appear

#### Linked Issues ####
https://github.com/rancher/rke2/issues/48

