### PR TITLE
Set tunnel controller certificate CN from build-time program name

### DIFF
--- a/pkg/agent/netpol/network_policy.go
+++ b/pkg/agent/netpol/network_policy.go
@@ -32,7 +32,8 @@ func Run(ctx context.Context, nodeConfig *config.Node) error {
 		return err
 	}
 
-	// retry backoff to wait for the clusterrolebinding of user "system:k3s-controller"
+	// retry backoff to wait for the clusterrolebinding for the k3s tunnel controller (system:k3s-controller or equivalent)
+	// which has to occur before it can bring up the connection to the API server.
 	retryBackoff := wait.Backoff{
 		Steps:    6,
 		Duration: 100 * time.Millisecond,

--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -551,8 +551,8 @@ func genClientCerts(config *config.Control, runtime *config.ControlRuntime) erro
 	if _, err = factory("system:kube-proxy", nil, runtime.ClientKubeProxyCert, runtime.ClientKubeProxyKey); err != nil {
 		return err
 	}
-	// this must be hardcoded to k3s-controller because it's hard coded in the rolebindings.yaml
-	if _, err = factory("system:k3s-controller", nil, runtime.ClientK3sControllerCert, runtime.ClientK3sControllerKey); err != nil {
+	// This user (system:k3s-controller by default) must be bound to a role in rolebindings.yaml or the downstream equivalent
+	if _, err = factory("system:"+version.Program+"-controller", nil, runtime.ClientK3sControllerCert, runtime.ClientK3sControllerKey); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Proposed Changes ####

Since we're replacing the k3s rolebindings.yaml in rke2, we should allow changing the CN on the agent tunnel controller cert so that we can use the white-labeled name downstream.

Note that this doesn't affect anything within the agent tunnel controller itself, it just needs to match the subject that we target with the rolebinding at https://github.com/rancher/k3s/blob/master/manifests/rolebindings.yaml#L62

#### Types of Changes ####

* k3s tunnel controller
* RBAC

#### Verification ####

* No change for k3s

#### Linked Issues ####

This will be needed as part of the fix for https://github.com/rancher/rke2/issues/324

#### Further Comments ####

Since we're finally dropping all the k3s manifests in rke2, we no longer need to keep the subject static to work with rolebindings.yaml.