### PR TITLE
[1.18 Backport] Only create k3s-images.txt on amd64

### DIFF
--- a/scripts/package-airgap
+++ b/scripts/package-airgap
@@ -8,5 +8,7 @@ cd $(dirname $0)/..
 airgap_image_file='scripts/airgap/image-list.txt'
 images=$(cat "${airgap_image_file}")
 xargs -n1 docker pull <<< "${images}"
-docker save ${images} -o dist/artifacts/k3s-airgap-images-${ARCH}.tar 
-cp "${airgap_image_file}" dist/artifacts/k3s-images.txt
+docker save ${images} -o dist/artifacts/k3s-airgap-images-${ARCH}.tar
+if [ ${ARCH} = amd64 ]; then
+  cp "${airgap_image_file}" dist/artifacts/k3s-images.txt
+fi


### PR DESCRIPTION
#### Proposed Changes ####

Backport of #2273 - Only create k3s-images.txt on amd64

#### Types of Changes ####

* CI

#### Verification ####

* Tag a release
* No more failed builds!

#### Linked Issues ####

#2271

#### Further Comments ####

The list is the same across architectures, and is validated against the
list in git as part of CI... so there's no reason to be pushing it from
every pipeline. It's also causing conflicts when multiple pipelines try
to upload it at the same time.

