### PR TITLE
Add trivy cache volume to build

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -40,7 +40,7 @@ ARG SELINUX=true
 ENV SELINUX $SELINUX
 
 ENV GO111MODULE off
-ENV DAPPER_RUN_ARGS --privileged -v k3s-cache:/go/src/github.com/rancher/k3s/.cache
+ENV DAPPER_RUN_ARGS --privileged -v k3s-cache:/go/src/github.com/rancher/k3s/.cache -v trivy-cache:/root/.cache/trivy
 ENV DAPPER_ENV REPO TAG DRONE_TAG IMAGE_NAME SKIP_VALIDATE GCLOUD_AUTH
 ENV DAPPER_SOURCE /go/src/github.com/rancher/k3s/
 ENV DAPPER_OUTPUT ./bin ./dist ./build/out


### PR DESCRIPTION
#### Proposed Changes ####

Adds Docker volume to cache the Trivy database, similar to how we mount a volume to cache go libraries.

#### Types of Changes ####

* Dapper
* CI

#### Verification ####

* Run CI build
* Note that it only downloads the Trivy DB once every 12 hours

#### Linked Issues ####

@cjellick do you have an issue for this?

#### Further Comments ####

If this works we'll need to do the same for other projects using Trivy to prevent rate-limiting