### PR TITLE
Mark k3s v1.18.9+k3s1 as stable

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.18.8+k3s1
+  latest: v1.18.9+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION
Mark k3s v1.18.9+k3s1 as stable in public channelserver

#### Linked Issues ####

https://github.com/rancher/k3s/issues/2225

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

