### PR TITLE
Skip etcd snapshots if the local endpoint is still a learner

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -391,7 +391,7 @@ func getClientConfig(ctx context.Context, runtime *config.ControlRuntime, endpoi
 	return cfg, nil
 }
 
-// toTLSConcif converts the ControlRuntime configuration to TLS configuration suitable
+// toTLSConfig converts the ControlRuntime configuration to TLS configuration suitable
 // for use by etcd.
 func toTLSConfig(runtime *config.ControlRuntime) (*tls.Config, error) {
 	clientCert, err := tls.LoadX509KeyPair(runtime.ClientETCDCert, runtime.ClientETCDKey)


### PR DESCRIPTION
#### Proposed Changes ####

Don't take snapshots if the local endpoint is still a learner

Also added doc comments where missing or incorrect

#### Types of Changes ####

* etcd

#### Verification ####

* start k3s with short snapshot interval (cron expression for every minute)
* note snapshots are skipped until node is no longer a learner

#### Linked Issues ####

Related to https://github.com/rancher/rke2/issues/292

#### Further Comments ####

We still need to properly handle nodes that join the etcd cluster but not k8s cluster, but this should fix the issue @rancher-max turned up when testing with very short snapshot invervals.

