### PR TITLE
Allow for multiple etcd snapshot restoration

### DIFF
--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/rancher/k3s/pkg/etcd"
 
 	"github.com/rancher/k3s/pkg/cluster/managed"
 	"github.com/rancher/k3s/pkg/version"
@@ -51,7 +52,7 @@ func (c *Cluster) testClusterDB(ctx context.Context) (<-chan struct{}, error) {
 // start starts the database, unless a cluster reset has been requested, in which case
 // it does that instead.
 func (c *Cluster) start(ctx context.Context) error {
-	resetFile := filepath.Join(c.config.DataDir, "db", "reset-flag")
+	resetFile := etcd.ResetFile(c.config)
 	if c.managedDB == nil {
 		return nil
 	}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -62,11 +62,7 @@ func (c *Cluster) start(ctx context.Context) error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("cluster-reset was successfully performed, "+
-				"please remove the cluster-reset flag and start %s normally, "+
-				"if you need to perform another cluster reset, "+
-				"you must first manually delete the %s file",
-				version.Program, resetFile)
+			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, i you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
 		}
 		return c.managedDB.Reset(ctx, c.clientAccessInfo)
 	}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -5,9 +5,14 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/rancher/k3s/pkg/version"
 
 	"github.com/rancher/k3s/pkg/cluster/managed"
 	"github.com/rancher/kine/pkg/endpoint"
@@ -47,13 +52,27 @@ func (c *Cluster) testClusterDB(ctx context.Context) (<-chan struct{}, error) {
 // start starts the database, unless a cluster reset has been requested, in which case
 // it does that instead.
 func (c *Cluster) start(ctx context.Context) error {
+	resetFile := filepath.Join(c.config.DataDir, "db", "reset-flag")
 	if c.managedDB == nil {
 		return nil
 	}
 
 	if c.config.ClusterReset {
+		if _, err := os.Stat(resetFile); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			return fmt.Errorf("cluster-reset was successfully performed, "+
+				"please remove the cluster-reset flag and start %s normally, "+
+				"if you need to perform another cluster reset, "+
+				"you must first manually delete the %s file",
+				version.Program, resetFile)
+		}
 		return c.managedDB.Reset(ctx, c.clientAccessInfo)
 	}
+	// removing the reset file and ignore error if the file doesnt exist
+	os.Remove(resetFile)
 
 	return c.managedDB.Start(ctx, c.clientAccessInfo)
 }

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -12,9 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rancher/k3s/pkg/version"
-
 	"github.com/rancher/k3s/pkg/cluster/managed"
+	"github.com/rancher/k3s/pkg/version"
 	"github.com/rancher/kine/pkg/endpoint"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -62,7 +62,7 @@ func (c *Cluster) start(ctx context.Context) error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, i you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
+			return fmt.Errorf("cluster-reset was successfully performed, please remove the cluster-reset flag and start %s normally, if you need to perform another cluster reset, you must first manually delete the %s file", version.Program, resetFile)
 		}
 		return c.managedDB.Reset(ctx, c.clientAccessInfo)
 	}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -120,6 +120,11 @@ func nameFile(config *config.Control) string {
 	return filepath.Join(etcdDBDir(config), "name")
 }
 
+// ResetFile returns the path to etcdDBDir/reset-flag
+func ResetFile(config *config.Control) string {
+	return filepath.Join(config.DataDir, "db", "reset-flag")
+}
+
 // IsInitialized checks to see if a WAL directory exists. If so, we assume that etcd
 // has already been brought up at least once.
 func (e *ETCD) IsInitialized(ctx context.Context, config *config.Control) (bool, error) {
@@ -172,8 +177,7 @@ func (e *ETCD) Reset(ctx context.Context, clientAccessInfo *clientaccess.Info) e
 		return err
 	}
 	// touch a file to avoid multiple resets
-	resetFile := filepath.Join(e.config.DataDir, "db", "reset-flag")
-	if err := ioutil.WriteFile(resetFile, []byte{}, 0600); err != nil {
+	if err := ioutil.WriteFile(ResetFile(e.config), []byte{}, 0600); err != nil {
 		return err
 	}
 	return e.newCluster(ctx, true)


### PR DESCRIPTION
#### Proposed Changes ####

Allow for multiple restoration

#### Types of Changes ####

enhancement to snapshot restore

#### Verification ####

- start k3s with cluster-init and snapshot schedule
- pass --cluster-reset and --cluster-reset-restore-path <snapshot>
- when k3s exits with message `INFO[0075] Etcd is running, restart without --cluster-reset flag now. Backup and delete ${datadir}/server/db on each peer etcd server and rejoin the nodes` run again with same flags

k3s should restore again the same snapshot, two etcd-old-<date> directory should be created in /var/lib/rancher/k3s/server/db/

#### Linked Issues ####

https://github.com/rancher/rke2/issues/353

