### PR TITLE
Update disables list when building with no_stage

### DIFF
--- a/pkg/cli/cmds/nostage.go
+++ b/pkg/cli/cmds/nostage.go
@@ -1,0 +1,9 @@
+// +build no_stage
+
+package cmds
+
+const (
+	// The coredns and servicelb controllers can still be disabled, even if their manifests
+	// are missing. Same with CloudController/ccm.
+	DisableItems = "coredns, servicelb"
+)

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	DisableItems = "coredns, servicelb, traefik, local-storage, metrics-server"
-
 	defaultSnapshotRentention    = 5
 	defaultSnapshotIntervalHours = 12
 )

--- a/pkg/cli/cmds/stage.go
+++ b/pkg/cli/cmds/stage.go
@@ -1,0 +1,10 @@
+// +build !no_stage
+
+package cmds
+
+const (
+	// coredns and servicelb run controllers that are turned off when their manifests are disabled.
+	// The k3s CloudController also has a bundled manifest and can be disabled via the
+	// --disable-cloud-controller flag or --disable=ccm, but the latter method is not documented.
+	DisableItems = "coredns, servicelb, traefik, local-storage, metrics-server"
+)


### PR DESCRIPTION
#### Proposed Changes ####

The --disable/--no-deploy flags actually turn off some built-in controllers, in addition to preventing manifests from getting loaded. Make it clear which controllers can still be disabled even when the packaged components are ommited by the no_stage build tag.

#### Types of Changes ####

* CLI

#### Verification ####

* Build k3s with no_stage tag
* Check `k3s --help | grep disable`

#### Linked Issues ####

Related to https://github.com/rancher/rke2/issues/376

#### Further Comments ####

I wasn't thinking about the controller-disabling side effect of the --disable flag when I committed https://github.com/rancher/rke2/pull/361 - so I will need to partially revert that after this is pulled in.