### PR TITLE
Revert removal of EndpointName hooks

### DIFF
--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -73,8 +73,12 @@ func (c *Cluster) initClusterDB(ctx context.Context, handler http.Handler) (http
 	return c.managedDB.Register(ctx, c.config, handler)
 }
 
-// assignManagedDriver checks to see if any managed databases are already configured or should be created/joined.
-// If a driver has been initialized it is used, otherwise we create or join a cluster using the default driver.
+// assignManagedDriver assigns a driver based on a number of different configuration variables.
+// If a driver has been initialized it is used.
+// If the configured endpoint matches the name of a driver, that driver is used.
+// If no specific endpoint has been requested and creating or joining has been requested,
+// we use the default driver.
+// If none of the above are true, no managed driver is assigned.
 func (c *Cluster) assignManagedDriver(ctx context.Context) error {
 	// Check all managed drivers for an initialized database on disk; use one if found
 	for _, driver := range managed.Registered() {
@@ -86,6 +90,8 @@ func (c *Cluster) assignManagedDriver(ctx context.Context) error {
 		}
 	}
 
+	// This is needed to allow downstreams to override driver selection logic by
+	// setting ServerConfig.Datastore.Endpoint such that it will match a driver's EndpointName
 	endpointType := strings.SplitN(c.config.Datastore.Endpoint, ":", 2)[0]
 	for _, driver := range managed.Registered() {
 		if endpointType == driver.EndpointName() {


### PR DESCRIPTION
#### Proposed Changes ####

* Revert commit that broke rke2 etcd.
* Add comments explaining what code is for

#### Types of Changes ####

* Managed DB

#### Verification ####

* Build RKE2 with this branch
* Note that etcd pod is started and cluster functions properly, instead of starting kine+sqlite and then crashing

#### Linked Issues ####

N/A - @galal-hussein reported an inability to start RKE2 after updating to k3s@master and this was the result of the investigation.

#### Further Comments ####

I called out this block in code review and nobody could think of a reason to keep it.

I still don't know what the first bit is doing with checking for an etcd:// prefix on the endpoint string, but I'll leave it there without a comment until I can figure it out.