### PR TITLE
Add temporary fix for issue with interrupted etcd promote

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -53,6 +53,12 @@ func (c *Cluster) shouldBootstrapLoad(ctx context.Context) (bool, error) {
 			// If the database is initialized we skip bootstrapping; if the user wants to rejoin a
 			// cluster they need to delete the database.
 			logrus.Infof("Managed %s cluster bootstrap already complete and initialized", c.managedDB.EndpointName())
+			// This is a workaround for an issue that can be caused by terminating the cluster bootstrap before
+			// etcd is promoted from learner. Odds are we won't need this info, and we don't want to fail startup
+			// due to failure to retrieve it as this will break cold cluster restart, so we ignore any errors.
+			if c.config.JoinURL != "" && c.config.Token != "" {
+				c.clientAccessInfo, _ = clientaccess.ParseAndValidateTokenForUser(c.config.JoinURL, c.config.Token, "server")
+			}
 			return false, nil
 		} else if c.config.JoinURL == "" {
 			// Not initialized, not joining - must be initializing (cluster-init)


### PR DESCRIPTION
#### Proposed Changes ####

If available, store clientAccessInfo even if the managed database is already initialized. There is a timing issue with etcd startup - if the process is killed after the new node is joined to the etcd cluster, but before it is promoted to learner, it will need the info again on next startup to finish promoting itself.

#### Types of Changes ####

* Managed etcd

#### Verification ####

* Follow instructions in the linked issue. Should be possible to replicate by terminating any k3s or rke2 server just just after it joins the etcd cluster for the first time.

#### Linked Issues ####

This is a minimal fix for https://github.com/rancher/rke2/issues/392

#### Further Comments ####
