### PR TITLE
Backport 1.18 agent cacerts clientaccess

### DIFF
--- a/pkg/clientaccess/clientaccess.go
+++ b/pkg/clientaccess/clientaccess.go
@@ -159,7 +159,7 @@ func accessInfoToKubeConfig(destFile, server, token string) error {
 }
 
 func validateToken(u url.URL, cacerts []byte, username, password string) error {
-	u.Path = "/apis"
+	u.Path = "/cacerts"
 	_, err := get(u.String(), GetHTTPClient(cacerts), username, password)
 	if err != nil {
 		return errors.Wrap(err, "token is not valid")


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
Use `/cacerts` for clientaccess instead of `/apis` to follow 1.19 supervisor port change. 
https://github.com/rancher/k3s/commit/e5fe184a441ec5a61420a30aaf3d5e6524ebc08e#diff-fc9e094a7966f92b19b6a2a56eb78cd9L151
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
Join 1.18 agent to 1.19 server
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
#2311
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

