### PR TITLE
Use no_proxy env, add .svc and cluster domains

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -387,12 +387,20 @@ func writeToken(token, file, certs string) error {
 }
 
 func setNoProxyEnv(config *config.Control) error {
-	envList := strings.Join([]string{
-		os.Getenv("NO_PROXY"),
+	splitter := func(c rune) bool {
+		return c == ','
+	}
+	envList := []string{}
+	envList = append(envList, strings.FieldsFunc(os.Getenv("NO_PROXY"), splitter)...)
+	envList = append(envList, strings.FieldsFunc(os.Getenv("no_proxy"), splitter)...)
+	envList = append(envList,
+		".svc",
+		"."+config.ClusterDomain,
 		config.ClusterIPRange.String(),
 		config.ServiceIPRange.String(),
-	}, ",")
-	return os.Setenv("NO_PROXY", envList)
+	)
+	os.Unsetenv("no_proxy")
+	return os.Setenv("NO_PROXY", strings.Join(envList, ","))
 }
 
 func writeConfigSymlink(kubeconfig, kubeconfigSymlink string) error {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####
When building a default `NO_PROXY` environment variable we should include the lowercase `no_proxy` environment variable, and include the `.svc` and cluster domains.
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####
Bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####
See #2176
<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####
#2176
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

