### PR TITLE
Add information on reporting security issues

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security
+
+Rancher Labs supports responsible disclosure and endeavors to resolve security
+issues in a reasonable timeframe. To report a security vulnerability, email
+[security@rancher.com](mailto:security@rancher.com)

--- a/README.md
+++ b/README.md
@@ -145,3 +145,8 @@ Contributing
 ------------
 
 Please check out our [contributing guide](CONTRIBUTING.md) if you're interesting in contributing to k3s.
+
+Security
+--------
+
+Security issues in k3s can be reported by sending an email to [security@rancher.com](mailto:security@rancher.com). Please do not file issues about security issues.


### PR DESCRIPTION
Signed-off-by: Jeremy Katz <jeremy@tidelift.com>

#### Proposed Changes ####

This adds information on how to report security issues in k3s to the readme and the github format SECURITY.md

#### Types of Changes ####

Documentation

#### Verification ####

Simple documentation

#### Linked Issues ####

https://github.com/rancher/k3s/issues/2070

#### Further Comments ####

Trivial
