### PR TITLE
Add auto-install capability to install.sh for k3s-selinux

### DIFF
--- a/pkg/agent/syssetup/setup.go
+++ b/pkg/agent/syssetup/setup.go
@@ -31,6 +31,7 @@ func Configure() {
 	loadKernelModule("overlay")
 	loadKernelModule("nf_conntrack")
 	loadKernelModule("br_netfilter")
+	loadKernelModule("iptable_nat")
 
 	// Kernel is inconsistent about how devconf is configured for
 	// new network namespaces between ipv4 and ipv6. Make sure to


### PR DESCRIPTION
Signed-off-by: Chris Kim <oats87g@gmail.com>

#### Proposed Changes ####
This adds logic to auto-install the `k3s-selinux` and corresponding repositories on el7/el8 systems. This is an improvement over the existing logic today which simply has the user run a `yum` command as a workaround.

#### Types of Changes ####

Install script changes

#### Verification ####
This can be verified by attempting to install `K3s` on an EL7/EL8 system that falls into the following:

RHEL 7
RHEL 8
CentOS 7
CentOS 8
Oracle Linux 7
Oracle Linux 8

This should be checked through:

`INSTALL_K3S_CHANNEL=testing ./install.sh` which will install K3s using the testing channel

`INSTALL_K3S_CHANNEL=testing INSTALL_K3S_SKIP_SELINUX_RPM=true ./install.sh` which will install K3s but fail out because the K3s selinux RPM needs to be "manually" installed". Can be useful for things like airgap. 

For now, this will only work on the testing channel until we verify that the `k3s-selinux` rpm changes are valid and can be cut into stable and latest.
#### Linked Issues ####
https://github.com/rancher/k3s/issues/2184

#### Further Comments ####
