### PR TITLE
Use 'rm' from path in go generate

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 //go:generate go run pkg/codegen/cleanup/main.go
-//go:generate /bin/rm -rf pkg/generated
+//go:generate rm -rf pkg/generated
 //go:generate go run pkg/codegen/main.go
 //go:generate go fmt pkg/deploy/zz_generated_bindata.go
 //go:generate go fmt pkg/static/zz_generated_bindata.go


### PR DESCRIPTION
/bin/rm is less portable. On some distros, like nixos, it doesn't exist
at all.

Right now, [nixpkgs carries this patch](https://github.com/NixOS/nixpkgs/blob/a948654086898aa95541bcd2ab39325588dc3332/pkgs/applications/networking/cluster/k3s/patches/0001-Use-rm-from-path-in-go-generate.patch) in order to compile the k3s there, but this seems like a reasonable thing to just merge in upstream.