### PR TITLE
Make etcd use node private ip

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -130,7 +130,9 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	if cmds.AgentConfig.FlannelIface != "" && cmds.AgentConfig.NodeIP == "" {
 		cmds.AgentConfig.NodeIP = netutil.GetIPFromInterface(cmds.AgentConfig.FlannelIface)
 	}
-
+	if serverConfig.ControlConfig.PrivateIP == "" && cmds.AgentConfig.NodeIP != "" {
+		serverConfig.ControlConfig.PrivateIP = cmds.AgentConfig.NodeIP
+	}
 	if serverConfig.ControlConfig.AdvertiseIP == "" && cmds.AgentConfig.NodeExternalIP != "" {
 		serverConfig.ControlConfig.AdvertiseIP = cmds.AgentConfig.NodeExternalIP
 	}

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -137,8 +137,8 @@ type Control struct {
 
 	BindAddress string
 	SANs        []string
-
-	Runtime *ControlRuntime `json:"-"`
+	PrivateIP   string
+	Runtime     *ControlRuntime `json:"-"`
 }
 
 type ControlRuntimeBootstrap struct {

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -267,12 +267,11 @@ func (e *ETCD) Register(ctx context.Context, config *config.Control, l net.Liste
 	}
 	e.client = client
 
-	address, err := getAdvertiseAddress(config.AdvertiseIP)
+	address, err := getAdvertiseAddress(config.PrivateIP)
 	if err != nil {
 		return nil, nil, err
 	}
 	e.address = address
-
 	e.config.Datastore.Endpoint = endpoint
 	e.config.Datastore.Config.CAFile = e.runtime.ETCDServerCA
 	e.config.Datastore.Config.CertFile = e.runtime.ClientETCDCert


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Etcd now uses advertised ip, which is the node external ip if it was passed to the cli, this change makes etcd use node private ip by default 
#### Types of Changes ####

Bugfix

### Verfication ###

run k3s server with --cluster-init and --node-external-ip <node-ip> and make sure k3s is up and running

### Issue ###
https://github.com/rancher/k3s/issues/2345