### PR TITLE
Update sonobuoy version and use rancher mirrored image

### DIFF
--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -6,7 +6,7 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN if [ "${ARCH}" == "amd64" ] || [ "${ARCH}" == "arm64" ]; then \
-        VERSION=0.18.4 OS=linux && \
+        VERSION=0.19.0 OS=linux && \
         curl -sL "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_${ARCH}.tar.gz" | \
         tar -xzf - -C /usr/local/bin; \
     fi

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -4,10 +4,11 @@ RUN apk -U --no-cache add bash git gcc musl-dev docker curl jq coreutils python2
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
+ENV SONOBUOY_VERSION 0.19.0
 
 RUN if [ "${ARCH}" == "amd64" ] || [ "${ARCH}" == "arm64" ]; then \
-        VERSION=0.19.0 OS=linux && \
-        curl -sL "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_${ARCH}.tar.gz" | \
+        OS=linux && \
+        curl -sL "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_${OS}_${ARCH}.tar.gz" | \
         tar -xzf - -C /usr/local/bin; \
     fi
 
@@ -19,7 +20,7 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/$( \
 ENV TEST_CLEANUP true
 
 ENV DAPPER_RUN_ARGS --privileged --network host
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BUILD_EVENT IMAGE_NAME GCLOUD_AUTH
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BUILD_EVENT IMAGE_NAME GCLOUD_AUTH SONOBUOY_VERSION
 ENV DAPPER_SOURCE /go/src/github.com/rancher/k3s/
 ENV DAPPER_OUTPUT ./dist
 ENV DAPPER_DOCKER_SOCKET true

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y curl
-RUN curl -sfL https://github.com/heptio/sonobuoy/releases/download/v0.13.0/sonobuoy_0.13.0_linux_amd64.tar.gz | tar xvzf - -C /usr/bin
+RUN curl -sfL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.18.0/sonobuoy_0.18.0_linux_amd64.tar.gz | tar xvzf - -C /usr/bin
 COPY run-test.sh /usr/bin
 CMD ["/usr/bin/run-test.sh"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y curl
-RUN curl -sfL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.18.0/sonobuoy_0.18.0_linux_amd64.tar.gz | tar xvzf - -C /usr/bin
+RUN curl -sfL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.19.0/sonobuoy_0.19.0_linux_amd64.tar.gz | tar xvzf - -C /usr/bin
 COPY run-test.sh /usr/bin
 CMD ["/usr/bin/run-test.sh"]

--- a/e2e/run-test.sh
+++ b/e2e/run-test.sh
@@ -11,6 +11,6 @@ sed 's/localhost/server/g' /etc/rancher/k3s/k3s.yaml > /root/.kube/config
 export KUBECONFIG=/root/.kube/config
 cat /etc/rancher/k3s/k3s.yaml
 cat $KUBECONFIG
-sonobuoy run
+sonobuoy run --sonobuoy-image=rancher/sonobuoy-sonobuoy:v0.19.0
 sleep 15
 sonobuoy logs -f

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -193,6 +193,7 @@ sonobuoy-test() {
     sonobuoy run \
         --config=scripts/sonobuoy-config.json \
         --plugin-env=e2e.E2E_USE_GO_RUNNER=true \
+        --sonobuoy-image=rancher/sonobuoy-sonobuoy:v${SONOBUOY_VERSION:-0.19.0} \
         --kube-conformance-image-version=${VERSION_K8S} \
         --wait=30 \
         $@ &

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -32,7 +32,7 @@ if [ -z "$VERSION_CRICTL" ]; then
     VERSION_CRICTL="v0.0.0"
 fi
 
-VERSION_K8S=$(grep k8s.io/kubernetes go.mod | head -n1 | awk '{print $4}' | sed -e 's/[-+].*//')
+VERSION_K8S=$(grep 'k8s.io/kubernetes v' go.mod | head -n1 | awk '{print $2}')
 if [ -z "$VERSION_K8S" ]; then
     VERSION_K8S="v0.0.0"
 fi


### PR DESCRIPTION
#### Proposed Changes ####

Update sonobuoy version and move to rancher-mirrored image

#### Types of Changes ####

* CI

#### Verification ####

* Check CI logs, confirm that sonobuoy tests are using rancher/sonobuoy-sonobuoy instead of sonobuoy/sonobuoy

#### Linked Issues ####

Related to #2479 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

