### PR TITLE
[backport 1.18] cri: pull in updated /dev/shm fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	github.com/containerd/console => github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
 	github.com/containerd/containerd => github.com/rancher/containerd v1.3.3-k3s2
 	github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02
-	github.com/containerd/cri => github.com/rancher/cri v1.3.0-k3s.8 // k3s-release/1.3
+	github.com/containerd/cri => github.com/rancher/cri v1.3.0-k3s.9 // k3s-release/1.3
 	github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 	github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda
 	github.com/containerd/typeurl => github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/rakelkar/gonetsh v0.0.0-20190719023240-501daadcadf8 h1:83l9gPhYtgxODl
 github.com/rakelkar/gonetsh v0.0.0-20190719023240-501daadcadf8/go.mod h1:4XHkfaUj+URzGO9sohoAgt2V9Y8nIW7fugpu0E6gShk=
 github.com/rancher/containerd v1.3.3-k3s2 h1:RZr+TqFt7+YsrSYkyytlhW4HmneWeFNM7IymNOoGW6A=
 github.com/rancher/containerd v1.3.3-k3s2/go.mod h1:ZMfzmqce2Z+QSEqdHMfeJs1TZ/UeJ1aDrazjpQT4ehM=
-github.com/rancher/cri v1.3.0-k3s.8 h1:qUdbZ6n3hAg3ImloQ6FMOtG8CG/JMNZ8vSuL47BCABA=
-github.com/rancher/cri v1.3.0-k3s.8/go.mod h1:Ht5T1dIKzm+4NExmb7wDVG6qR+j0xeXIjjhCv1d9geY=
+github.com/rancher/cri v1.3.0-k3s.9 h1:lCvxoN843aZTTGbcaZdO1rhEAr8BTcraMz6EP/i3YgM=
+github.com/rancher/cri v1.3.0-k3s.9/go.mod h1:Ht5T1dIKzm+4NExmb7wDVG6qR+j0xeXIjjhCv1d9geY=
 github.com/rancher/cri-tools v1.18.0-k3s1 h1:pLYthxpSu6k3Up9tNAMA0MK2ERqB6FC1sZQPRSW1qSg=
 github.com/rancher/cri-tools v1.18.0-k3s1/go.mod h1:Ij/GWNRcEDP6zVN6eQpvN/s0nhuJVtPQFy7RAdl+Wu8=
 github.com/rancher/dynamiclistener v0.2.0 h1:KucYwJXVVGhZ/NndfMCeQoCafT/VN7kvqSGgmlX8Lxk=

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -550,7 +550,7 @@ func (c *criService) generateContainerMounts(sandboxID string, config *runtime.C
 			ContainerPath:  devShm,
 			HostPath:       sandboxDevShm,
 			Readonly:       false,
-			SelinuxRelabel: true,
+			SelinuxRelabel: sandboxDevShm != devShm,
 		})
 	}
 	return mounts

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/containerd/continuity/pathdriver
 github.com/containerd/continuity/proto
 github.com/containerd/continuity/syscallx
 github.com/containerd/continuity/sysx
-# github.com/containerd/cri v0.0.0-00010101000000-000000000000 => github.com/rancher/cri v1.3.0-k3s.8
+# github.com/containerd/cri v0.0.0-00010101000000-000000000000 => github.com/rancher/cri v1.3.0-k3s.9
 github.com/containerd/cri
 github.com/containerd/cri/pkg/annotations
 github.com/containerd/cri/pkg/api/runtimeoptions/v1


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

Do not relabel container /dev/shm when it is host /dev/shm.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

bugfix
<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

```shell
kubectl run envoy --image=envoyproxy/envoy:v1.14.1
pod/envoy created
# after some seconds, should get a running pod:
kubectl get pod
NAME    READY   STATUS    RESTARTS   AGE
envoy   1/1     Running   0          18s
```

Additionally, with HostIPC=true:
```shell
kubectl run envoy --image=envoyproxy/envoy:v1.14.1 --overrides='{ "apiVersion": "v1", "spec": { "hostIPC" : true} }'
pod/envoy created
# after some seconds, should get a running pod:
kubectl get pod
NAME    READY   STATUS    RESTARTS   AGE
envoy   1/1     Running   0          18s
```
And a directory listing of `/dev/shm` should look like:
```shell
ls -alZ /dev/shm/
drwxrwxrwt. root root system_u:object_r:tmpfs_t:s0     .
drwxr-xr-x. root root system_u:object_r:device_t:s0    ..
-rw-------. root root system_u:object_r:container_file_t:s0 envoy_shared_memory_0
```

Specifically, `/dev/shm` should NOT have the `container_file_t` context label.

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#2240 

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Backports https://github.com/containerd/cri/pull/1605 to 1.3