### PR TITLE
Mark v1.19.4+k3s1 as stable

### DIFF
--- a/channel.yaml
+++ b/channel.yaml
@@ -1,7 +1,7 @@
 # Example channels config
 channels:
 - name: stable
-  latest: v1.19.3+k3s3
+  latest: v1.19.4+k3s1
 - name: latest
   latestRegexp: .*
   excludeRegexp: ^[^+]+-


### PR DESCRIPTION

#### Proposed Changes ####

Mark v1.19.4+k3s1 as stable
#### Types of Changes ####

channelsever

#### Verification ####

install k3s via the curl command(without passing a channel or setting channel to stable) the installed version should be v1.19.4+k3s1 
#### Linked Issues ####

https://github.com/rancher/k3s/issues/2574


