### PR TITLE
rootless: fix "stat /run/user/1000: no such file or directory" on `kubectl run`

### DIFF
--- a/pkg/rootless/mounts.go
+++ b/pkg/rootless/mounts.go
@@ -15,8 +15,6 @@ import (
 
 func setupMounts(stateDir string) error {
 	mountMap := [][]string{
-		{"/run", ""},
-		{"/var/run", ""},
 		{"/var/log", filepath.Join(stateDir, "logs")},
 		{"/var/lib/cni", filepath.Join(stateDir, "cni")},
 		{"/var/lib/kubelet", filepath.Join(stateDir, "kubelet")},


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Fix "stat /run/user/1000: no such file or directory" error that happend on `kubectl run` because
k3s was mounting a tmpfs on `/run` by itself and hiding RootlessKit's `/run`.


#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

```console
$ k3s server --rootless
```

```console
$ KUBECONFIG=~/.kube/k3s.yaml kubectl run -it --rm --image=alpine --restart=Never foo
If you don't see a command prompt, try pressing enter.
/ # 
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

Fix #2421 
#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

